### PR TITLE
Increase dependabot frequency to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,4 @@ updates:
     directory: '/'
     # Check the npm registry for updates every day (weekdays)
     schedule:
-      interval: 'weekly'
+      interval: 'daily'


### PR DESCRIPTION
5 PRs a week seems too slow to keep up with all these packages. Let's
bump the frequency back up to the default 'daily'.

Fixes: nmkataoka/adv-life#

## Checklist

- [x] PR is of reasonable size
