### PR TITLE
Add ground to Colosseum

### DIFF
--- a/src/0-engine/ECS/View.ts
+++ b/src/0-engine/ECS/View.ts
@@ -26,7 +26,7 @@ export class View<
     this.withoutCMgrs = withoutCmpts.map((CClass) => eMgr.tryGetMgr(CClass)) as CMgrs<WithoutCmpts>;
 
     this.entities = FindEntitiesWithComponents(
-      [...this.readCMgrs, ...this.withoutCMgrs],
+      [...this.readCMgrs, ...this.writeCMgrs, ...this.withoutCMgrs],
       withoutCmpts.length,
     );
   }

--- a/src/0-engine/SystemList.ts
+++ b/src/0-engine/SystemList.ts
@@ -5,6 +5,7 @@ import { StatusEffectsSys } from '1-game-code/Combat/StatusEffectsSys';
 import { CombatLogSys } from '1-game-code/Combat/CombatLogSys';
 import { CharacterCreationSys } from '1-game-code/CharacterCreation/CharacterCreationSys';
 import { MerchantSys } from '1-game-code/Merchant/MerchantSys';
+import { MovementSys } from '1-game-code/Combat/MovementSys';
 import { ItemClassDbSys } from '1-game-code/Items/ItemClass/ItemClassDbSys';
 import { MaterialDbSys } from '1-game-code/Items/Material/MaterialDbSys';
 import { EventSys } from './ECS/event-system/EventSys';
@@ -22,6 +23,7 @@ const SystemList: ECSystemConstructor<any>[] = [
   ItemClassDbSys,
   ManaRegenSys,
   MaterialDbSys,
+  MovementSys,
   MerchantSys,
   StatusEffectsSys,
 ];

--- a/src/1-game-code/CharacterCreation/CharacterCreationSys.ts
+++ b/src/1-game-code/CharacterCreation/CharacterCreationSys.ts
@@ -18,11 +18,11 @@ const createCharacter = ({
   payload: { className, name, personality, race, stats },
   ack,
 }: EventCallbackArgs<{
-  className: string;
+  className?: string;
   name: string;
-  personality: PersonalityArray;
-  race: string;
-  stats: Stats;
+  personality?: PersonalityArray;
+  race?: string;
+  stats?: Stats;
 }>) => {
   const playerAlreadyExists = eMgr.getView([PlayerCmpt], [], []).count > 0;
   if (playerAlreadyExists) {

--- a/src/1-game-code/Combat/CombatPositionCmpt.ts
+++ b/src/1-game-code/Combat/CombatPositionCmpt.ts
@@ -1,8 +1,11 @@
 import { NComponent } from '0-engine';
+import { Vector2 } from '8-helpers/math';
 
 // Controls the order in which units are displayed on the board.
 // Positions may not be continuous or whole numbers.
 // E.g. [1, 3, 99.5, 100] is a valid set of unit positions
 export class CombatPositionCmpt implements NComponent {
   public position = -1;
+
+  public pos = new Vector2(0, 0);
 }

--- a/src/1-game-code/Combat/MovementCmpt.ts
+++ b/src/1-game-code/Combat/MovementCmpt.ts
@@ -1,0 +1,8 @@
+import { NComponent } from '0-engine';
+import { Vector2 } from '8-helpers/math';
+
+export class MovementCmpt implements NComponent {
+  public speed = 1;
+
+  public destination = new Vector2(0, 0);
+}

--- a/src/1-game-code/Combat/MovementSys.ts
+++ b/src/1-game-code/Combat/MovementSys.ts
@@ -1,0 +1,25 @@
+import { ECSystem } from '0-engine';
+import { CombatPositionCmpt } from './CombatPositionCmpt';
+import { MovementCmpt } from './MovementCmpt';
+
+export class MovementSys extends ECSystem {
+  public Start(): void {}
+
+  public OnUpdate(dt: number): void {
+    this.moveUnits(dt);
+  }
+
+  private moveUnits(dt: number) {
+    const view = this.eMgr.getView<[], [MovementCmpt, CombatPositionCmpt]>(
+      [],
+      [MovementCmpt, CombatPositionCmpt],
+    );
+    view.forEach((e: number, _, [movementCmpt, combatPosCmpt]) => {
+      const { speed, destination } = movementCmpt;
+      const { pos } = combatPosCmpt;
+      const dir = destination.subtract(pos);
+      const movement = dir.multiply(speed * dt);
+      combatPosCmpt.pos.addMut(movement);
+    });
+  }
+}

--- a/src/3-frontend-api/characterCreation.ts
+++ b/src/3-frontend-api/characterCreation.ts
@@ -1,6 +1,6 @@
 import { PersonalityArray } from '1-game-code/ncomponents';
 import { CREATE_CHARACTER } from '2-backend-api/controllers/CharacterCreationConstants';
-import apiClient, { AckCallback } from './ApiClient';
+import apiClient, { AckCallback } from '3-frontend-api/ApiClient';
 
 export type Stats = {
   dexterity: number;

--- a/src/6-ui-features/ColosseumScene/Ground.tsx
+++ b/src/6-ui-features/ColosseumScene/Ground.tsx
@@ -1,0 +1,34 @@
+import { MeshProps } from '9-three-helpers';
+import React, { useState } from 'react';
+import { MouseEvent } from 'react-three-fiber';
+import { Vector3 } from 'three';
+
+const X = (props: MeshProps) => {
+  return (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <mesh {...props}>
+      <boxBufferGeometry args={[1, 1, 1]} />
+      <meshStandardMaterial color="blue" />
+    </mesh>
+  );
+};
+
+export default function Ground(props: MeshProps): JSX.Element {
+  const [xposition, setXposition] = useState<null | Vector3>(null);
+
+  const handleClick = (e: MouseEvent) => {
+    const pos = e.intersections[0]?.point;
+    pos.setZ(0);
+    setXposition(pos);
+  };
+
+  return (
+    <>
+      {xposition != null && <X position={xposition} />}
+      {/* eslint-disable-next-line react/jsx-props-no-spreading */}
+      <mesh {...props} onClick={handleClick}>
+        <planeBufferGeometry args={[100, 50, 1, 1]} />
+      </mesh>
+    </>
+  );
+}

--- a/src/6-ui-features/ColosseumScene/Unit/index.tsx
+++ b/src/6-ui-features/ColosseumScene/Unit/index.tsx
@@ -2,26 +2,36 @@ import { MeshProps } from '9-three-helpers';
 import React, { useRef, useState } from 'react';
 import { Mesh } from 'three';
 
-export default function Unit(props: MeshProps): JSX.Element {
+type UnitProps = MeshProps & {
+  color?: string;
+};
+
+export default function Unit(props: UnitProps): JSX.Element {
   // This reference will give us direct access to the mesh
   const mesh = useRef<Mesh>();
+  const { color = 'orange', ...meshProps } = props;
 
   // Set up state for the hovered and active state
   const [hovered, setHover] = useState(false);
   const [active, setActive] = useState(false);
 
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setActive(!active);
+  };
+
   return (
     <mesh
       // eslint-disable-next-line react/jsx-props-no-spreading
-      {...props}
+      {...meshProps}
       ref={mesh}
       scale={active ? [1.5, 1.5, 1.5] : [1, 1, 1]}
-      onClick={() => setActive(!active)}
+      onClick={handleClick}
       onPointerOver={() => setHover(true)}
       onPointerOut={() => setHover(false)}
     >
       <circleBufferGeometry args={[1, 32]} />
-      <meshStandardMaterial color={hovered ? 'hotpink' : 'orange'} />
+      <meshStandardMaterial color={hovered ? 'hotpink' : color} />
     </mesh>
   );
 }

--- a/src/6-ui-features/ColosseumScene/index.tsx
+++ b/src/6-ui-features/ColosseumScene/index.tsx
@@ -1,14 +1,17 @@
 import React from 'react';
 import { Canvas } from 'react-three-fiber';
+import Ground from './Ground';
 import Unit from './Unit';
 
 export default function ColosseumScene(): JSX.Element {
   return (
     <Canvas>
+      <Ground position={[0, 0, -1]} />
       <ambientLight />
       <pointLight position={[10, 10, 10]} />
       <Unit position={[-1.2, 0, 0]} />
-      <Unit position={[1.2, 0, 0]} />
+      <Unit position={[1.2, 0, 0]} color="red" />
+      <Unit position={[4.2, 0, 0]} color="red" />
     </Canvas>
   );
 }

--- a/src/8-helpers/math/Vector2.test.ts
+++ b/src/8-helpers/math/Vector2.test.ts
@@ -6,7 +6,7 @@ describe('Vector2', () => {
 
   beforeEach(() => {
     a = new Vector2(1, 2);
-    b = new Vector2(3, 4);
+    b = new Vector2(3, 5);
   });
 
   it('add returns correct Vector2 and does not mutate', () => {
@@ -14,8 +14,8 @@ describe('Vector2', () => {
     const s = b.add(a);
     expect(r.x).toBe(4);
     expect(s.x).toBe(4);
-    expect(r.y).toBe(6);
-    expect(s.y).toBe(6);
+    expect(r.y).toBe(7);
+    expect(s.y).toBe(7);
 
     expect(a.x).toBe(1);
     expect(a.y).toBe(2);
@@ -25,14 +25,14 @@ describe('Vector2', () => {
     const r = a.addMut(b);
     expect(r).toBe(a);
     expect(r.x).toBe(4);
-    expect(r.y).toBe(6);
+    expect(r.y).toBe(7);
   });
 
   it('dist returns correct number', () => {
     const r = a.dist(b);
     const s = b.dist(a);
     expect(r).toBe(s);
-    expect(r).toBe(Math.sqrt(16 + 36));
+    expect(r).toBe(Math.sqrt(13));
   });
 
   it('multiply returns correct Vector2 and does not mutate', () => {
@@ -46,7 +46,7 @@ describe('Vector2', () => {
   it('subtract returns correct Vector2', () => {
     const r = a.subtract(b);
     expect(r.x).toBe(-2);
-    expect(r.y).toBe(-2);
+    expect(r.y).toBe(-3);
     expect(a.x).toBe(1);
     expect(a.y).toBe(2);
   });
@@ -55,6 +55,6 @@ describe('Vector2', () => {
     const r = a.subtractMut(b);
     expect(r).toBe(a);
     expect(r.x).toBe(-2);
-    expect(r.y).toBe(-2);
+    expect(r.y).toBe(-3);
   });
 });

--- a/src/8-helpers/math/Vector2.test.ts
+++ b/src/8-helpers/math/Vector2.test.ts
@@ -1,0 +1,60 @@
+import { Vector2 } from './Vector2';
+
+describe('Vector2', () => {
+  let a: Vector2;
+  let b: Vector2;
+
+  beforeEach(() => {
+    a = new Vector2(1, 2);
+    b = new Vector2(3, 4);
+  });
+
+  it('add returns correct Vector2 and does not mutate', () => {
+    const r = a.add(b);
+    const s = b.add(a);
+    expect(r.x).toBe(4);
+    expect(s.x).toBe(4);
+    expect(r.y).toBe(6);
+    expect(s.y).toBe(6);
+
+    expect(a.x).toBe(1);
+    expect(a.y).toBe(2);
+  });
+
+  it('addMut returns correct Vector2, mutates, and returns own reference', () => {
+    const r = a.addMut(b);
+    expect(r).toBe(a);
+    expect(r.x).toBe(4);
+    expect(r.y).toBe(6);
+  });
+
+  it('dist returns correct number', () => {
+    const r = a.dist(b);
+    const s = b.dist(a);
+    expect(r).toBe(s);
+    expect(r).toBe(Math.sqrt(16 + 36));
+  });
+
+  it('multiply returns correct Vector2 and does not mutate', () => {
+    const r = a.multiply(3);
+    expect(r.x).toBe(3);
+    expect(r.y).toBe(6);
+    expect(a.x).toBe(1);
+    expect(a.y).toBe(2);
+  });
+
+  it('subtract returns correct Vector2', () => {
+    const r = a.subtract(b);
+    expect(r.x).toBe(-2);
+    expect(r.y).toBe(-2);
+    expect(a.x).toBe(1);
+    expect(a.y).toBe(2);
+  });
+
+  it('subtractMut returns correct Vector2, mutates, and returns own reference', () => {
+    const r = a.subtractMut(b);
+    expect(r).toBe(a);
+    expect(r.x).toBe(-2);
+    expect(r.y).toBe(-2);
+  });
+});

--- a/src/8-helpers/math/Vector2.ts
+++ b/src/8-helpers/math/Vector2.ts
@@ -1,0 +1,47 @@
+export class Vector2 {
+  public x = 0;
+
+  public y = 0;
+
+  constructor(x: number, y: number) {
+    this.x = x;
+    this.y = y;
+  }
+
+  /** Adds to another Vector2 */
+  public add(b: Vector2): Vector2 {
+    return new Vector2(this.x + b.x, this.y + b.y);
+  }
+
+  /** Adds `b` to this Vector2 (mutates). Returns a reference to self.
+   */
+  public addMut(b: Vector2): Vector2 {
+    this.x += b.x;
+    this.y += b.y;
+    return this;
+  }
+
+  /** Calculates the distance to another Vector2 */
+  public dist(b: Vector2): number {
+    const xDiff = this.x - b.x;
+    const yDiff = this.y - b.y;
+    return Math.sqrt(xDiff * xDiff + yDiff * yDiff);
+  }
+
+  /** Subtracts another Vector2 and returns the result as a new Vector2 */
+  public subtract(b: Vector2): Vector2 {
+    return new Vector2(this.x - b.x, this.y - b.y);
+  }
+
+  /** Subtracts another Vector2 in place (mutates). Returns reference to self. */
+  public subtractMut(b: Vector2): Vector2 {
+    this.x -= b.x;
+    this.y -= b.y;
+    return this;
+  }
+
+  /** Multiplies by a scalar and returns as a new vector */
+  public multiply(c: number): Vector2 {
+    return new Vector2(this.x * c, this.y * c);
+  }
+}

--- a/src/8-helpers/math/index.ts
+++ b/src/8-helpers/math/index.ts
@@ -1,0 +1,1 @@
+export { Vector2 } from './Vector2';


### PR DESCRIPTION
Fixes: nmkataoka/adv-life#165

Started working on letting the player move around in the Colosseum
scene but I'm stopping partway through to refactor, simplify, and
standardize some of the engine architecture.

- Added a Ground background component that can react to clicks to the
  Colosseum scene.
- Fixed a bug in View instantiation where the write component managers
  weren't being fetched.
- Created a Vector2 class that will standardize coordinate math.

## Checklist

- [x] PR is of reasonable size
