### PR TITLE
Port fault rasterization

### DIFF
--- a/src/1-game-code/World/TerrainGen/RasterizeTecPlates.ts
+++ b/src/1-game-code/World/TerrainGen/RasterizeTecPlates.ts
@@ -1,17 +1,49 @@
+import assert from 'assert';
+import { multiply, subtract } from '8-helpers/math/Vector2';
 import { fillInHoles } from './fillInHoles';
 import { DataLayer } from '../DataLayer';
+import { getBaseElevation } from './TecPlate';
+import { simpleBresenham } from './simpleBresenham';
+import { Fault } from './Fault';
 
-export function rasterizeTecPlates(elevLayer: DataLayer, numPlates: number): void {
+export function rasterizeTecPlates(elevLayer: DataLayer, numPlates: number, faults: Fault[]): void {
   fillInHoles(elevLayer, numPlates);
-  rasterizeFaults();
+  rasterizeFaults(elevLayer, faults);
 }
 
 /** Start rasterizing from vector representation of TecPlates to a grid.
  * First up is the faults.
  */
-function rasterizeFaults() {
-  // We need to write the plate elevations on either side of the fault
-  // just wide enough to ensure no gaps so the floodfill algorithm works
-  // Elevation profiles are propagated in parallelograms between fault vertices
-  // in the direction of normalDir (and its negative)
+function rasterizeFaults(elevLayer: DataLayer, faults: Fault[]) {
+  const { height } = elevLayer;
+  for (let i = 0; i < faults.length; ++i) {
+    const fault = faults[i];
+    const { normalDir, tecPlateHigher, tecPlateLower, vertices } = fault;
+    const higherElev = getBaseElevation(tecPlateHigher);
+    const lowerElev = getBaseElevation(tecPlateLower);
+
+    assert(vertices.length > 2);
+
+    // We need to write the plate elevations on either side of the fault
+    // just wide enough to ensure no gaps so the floodfill algorithm works
+    // Elevation profiles are propagated in parallelograms between fault vertices
+    // in the direction of normalDir (and its negative)
+
+    // Apply elevations along the ridge
+    for (let curIdx = 1; curIdx < vertices.length; ++curIdx) {
+      const cur = vertices[curIdx];
+      const prev = vertices[curIdx - 1];
+      const fSegSlope = subtract(cur, prev);
+      simpleBresenham(prev, cur, fSegSlope, normalDir, 5, (x: number, y: number) => {
+        if (y < height && y >= 0) {
+          elevLayer.set(x, y, higherElev);
+        }
+      });
+      simpleBresenham(prev, cur, fSegSlope, multiply(normalDir, -1), 5, (x: number, y: number) => {
+        if (y < height && y >= 0) {
+          elevLayer.set(x, y, lowerElev);
+        }
+      });
+    }
+  }
 }

--- a/src/1-game-code/World/TerrainGen/TecPlates.ts
+++ b/src/1-game-code/World/TerrainGen/TecPlates.ts
@@ -1,6 +1,6 @@
 import { Vector2, rotate } from '8-helpers/math/Vector2';
-import { Fault } from './Fault';
-import { getBaseElevation, TecPlate } from './TecPlate';
+import { createFaultFromEdge, Fault } from './Fault';
+import { TecPlate } from './TecPlate';
 import { generateVoronoi, Edge, Polygon, VoronoiDiagram } from './Voronoi';
 
 export type TecPlates = {
@@ -97,21 +97,7 @@ function createPlatesAndFaults(
     const edgeHash = hashEdge(edge, xSize, ySize);
     const adjacentTecPlates = edgesToTecPlates[edgeHash];
     const [plateA, plateB] = adjacentTecPlates;
-    let tecPlateHigher: TecPlate;
-    let tecPlateLower: TecPlate;
-
-    if (getBaseElevation(plateA) < getBaseElevation(plateB)) {
-      tecPlateHigher = plateB;
-      tecPlateLower = plateA;
-    } else {
-      tecPlateHigher = plateA;
-      tecPlateLower = plateB;
-    }
-
-    const fault: Fault = {
-      tecPlateHigher,
-      tecPlateLower,
-    };
+    const fault = createFaultFromEdge(edge, plateA, plateB);
     hashedEdgesToFaults[edgeHash] = fault;
     return fault;
   });

--- a/src/1-game-code/World/TerrainGen/lessThan.ts
+++ b/src/1-game-code/World/TerrainGen/lessThan.ts
@@ -1,0 +1,10 @@
+import { Vector2 } from '8-helpers/math/Vector2';
+
+/** Sorts by x first, then y. Useful if a consistent order is desired for a set map-related points. */
+export function lessThan(a: Vector2, b: Vector2): boolean {
+  const [ax, ay] = a;
+  const [bx, by] = b;
+  if (ax < bx) return true;
+  if (ax === bx && ay < by) return true;
+  return false;
+}

--- a/src/1-game-code/World/TerrainGen/simpleBresenham.ts
+++ b/src/1-game-code/World/TerrainGen/simpleBresenham.ts
@@ -1,0 +1,45 @@
+import { Vector2 } from '8-helpers/math';
+import { add, multiply, norm } from '8-helpers/math/Vector2';
+
+/** Slightly less than sqrt(2)/2, ensures no tiles are skipped */
+const bresenSpacing = 0.7;
+
+/** Rasterization algorithm. Draws lines parallel to fault slope spaced out
+ * sqrt(2)/2 apart using Bresenham's line algorithm, going out from fault.
+ *
+ * There is an alternate algorithm that involves rasterizing parellograms
+ * by breaking them into 4 triangles and assigning profile[(int)distanceToFault].
+ * This guarantees optimal profile application, but uses many expensive sqrt()
+ * calculations.
+ */
+export function simpleBresenham(
+  prev: Vector2,
+  cur: Vector2,
+  segmentSlope: Vector2,
+  stepDir: Vector2,
+  width: number,
+  func: (a: number, b: number) => void,
+): void {
+  const segLength = norm(segmentSlope);
+  /** How much we'll step from the fault */
+  const stepFromFault = multiply(stepDir, bresenSpacing);
+  /** How much we'll step along the Bresenham Line */
+  const stepToCur = multiply(segmentSlope, bresenSpacing / segLength);
+  const fSteps = Math.floor(segLength / bresenSpacing) + 1;
+
+  let prevStart = prev;
+  // Step Bresenham line away from fault
+  for (let i = 0; i < width; ++i) {
+    let ver = prevStart;
+    // Walk along Bresenham line
+    for (let j = 0; j < fSteps; ++j) {
+      // Apply function (such as assigning an elevation to a point)
+      const [x, y] = ver;
+      const intifiedX = Math.floor(x);
+      const intifiedY = Math.floor(y);
+      func(intifiedX, intifiedY);
+      ver = add(ver, stepToCur);
+    }
+    prevStart = add(prevStart, stepFromFault);
+  }
+}

--- a/src/8-helpers/math/Vector2.ts
+++ b/src/8-helpers/math/Vector2.ts
@@ -31,6 +31,11 @@ export function dot(a: Vector2, b: Vector2): number {
   return ax * bx + ay * by;
 }
 
+/** Returns the magnitude of the vector */
+export function norm(a: Vector2): number {
+  return dot(a, a);
+}
+
 /** Rotates a vector by `theta` radians */
 export function rotate(a: Vector2, theta: number): Vector2 {
   const [x, y] = a;


### PR DESCRIPTION
- Added bresenham line algorithm for rasterization
- Added rasterization using bresenham helpers
- Added `lessThan` point comparator. In C++ difclone, used a lot of
  point sorting. Not sure if we'll still need this here given we're
  using a library for most voronoi stuff. Sorting may still be needed
  for relaxation or rasterization.

Fixes: nmkataoka/adv-life#227

## Checklist

- [x] PR is of reasonable size
