### PR TITLE
Delay world map creation, remove world map from main menu

### DIFF
--- a/src/1-game-code/World/DataLayer.ts
+++ b/src/1-game-code/World/DataLayer.ts
@@ -14,11 +14,13 @@ export class DataLayer {
     this.metersPerCoord = metersPerCoord;
   }
 
+  /** Safe access, but slow */
   at = (x: number, y: number): number => {
     x = ((x % this.width) + this.width) % this.width;
     return this.data[this.width * y + x];
   };
 
+  /** Safe setting, but slow */
   set = (x: number, y: number, val: number): void => {
     x = ((x % this.width) + this.width) % this.width;
     this.data[this.width * y + x] = val;

--- a/src/1-game-code/World/TerrainGen/TerrainGenSys.ts
+++ b/src/1-game-code/World/TerrainGen/TerrainGenSys.ts
@@ -1,11 +1,12 @@
-import { copyEventSlice, createEventSlice, DefaultEvent } from '0-engine';
+import { createEventSlice } from '0-engine';
 import { WorldMapCmpt } from '../WorldMapCmpt';
 import { WorldMap } from '../WorldMap';
-// import { createRandomTerrain } from './createRandomTerrain';
+import { createRandomTerrain } from './elevationNoise/createRandomTerrain';
 import { generateTectonics } from './tectonicGeneration';
 import { rasterizeTectonics } from './tectonicRasterization';
 import { lowFreqNoise } from './elevationNoise/elevationNoise';
 
+/** This is mostly just for debugging now, or if the real world map breaks for an extended period of time. */
 const createNoisedWorldMapSlice = createEventSlice('createNoisedWorldMap', {
   writeCmpts: [WorldMapCmpt],
 })<undefined>(
@@ -15,10 +16,32 @@ const createNoisedWorldMapSlice = createEventSlice('createNoisedWorldMap', {
       writeCMgrs: [worldMapMgr],
     },
   }) => {
+    if (eMgr.getUniqueCmpt(WorldMapCmpt)) {
+      throw new Error('Attempted to create world map when world map already exists.');
+    }
+    const worldMapEntity = eMgr.createEntity('worldMap');
+    const worldMapCmpt = new WorldMapCmpt();
+    worldMapCmpt.data.dataLayers[WorldMap.Layer.Elevation] = createRandomTerrain();
+
+    worldMapMgr.add(worldMapEntity, worldMapCmpt);
+  },
+);
+
+const createWorldMapSlice = createEventSlice('createWorldMap', {
+  writeCmpts: [WorldMapCmpt],
+})<void>(
+  ({
+    eMgr,
+    componentManagers: {
+      writeCMgrs: [worldMapMgr],
+    },
+  }) => {
+    if (eMgr.getUniqueCmpt(WorldMapCmpt)) {
+      throw new Error('Attempted to create world map when world map already exists.');
+    }
     const worldMapEntity = eMgr.createEntity('worldMap');
     const worldMapCmpt = new WorldMapCmpt();
     const worldMap = worldMapCmpt.data;
-    // worldMapCmpt.data.dataLayers[WorldMap.Layer.Elevation] = createRandomTerrain();
     worldMap.tectonics = generateTectonics(18, 800, 400);
     worldMap.dataLayers[WorldMap.Layer.Elevation] = rasterizeTectonics(worldMap.tectonics);
     lowFreqNoise(worldMap.dataLayers[WorldMap.Layer.Elevation]);
@@ -26,9 +49,7 @@ const createNoisedWorldMapSlice = createEventSlice('createNoisedWorldMap', {
   },
 );
 
-// TODO: move this off of start into its own event
-const start = copyEventSlice(DefaultEvent.Start, createNoisedWorldMapSlice);
-
 export const { createNoisedWorldMap } = createNoisedWorldMapSlice;
+export const { createWorldMap } = createWorldMapSlice;
 
-export default [start.eventListener, createNoisedWorldMapSlice.eventListener];
+export default [createNoisedWorldMapSlice.eventListener, createWorldMapSlice.eventListener];

--- a/src/1-game-code/World/TerrainGen/TerrainGenSys.ts
+++ b/src/1-game-code/World/TerrainGen/TerrainGenSys.ts
@@ -29,11 +29,15 @@ const createNoisedWorldMapSlice = createEventSlice('createNoisedWorldMap', {
 
 const createWorldMapSlice = createEventSlice('createWorldMap', {
   writeCmpts: [WorldMapCmpt],
-})<void>(
+})<{ size: { x: number; y: number }; numPlates: number }>(
   ({
     eMgr,
     componentManagers: {
       writeCMgrs: [worldMapMgr],
+    },
+    payload: {
+      size: { x: xSize, y: ySize },
+      numPlates,
     },
   }) => {
     if (eMgr.getUniqueCmpt(WorldMapCmpt)) {
@@ -42,7 +46,7 @@ const createWorldMapSlice = createEventSlice('createWorldMap', {
     const worldMapEntity = eMgr.createEntity('worldMap');
     const worldMapCmpt = new WorldMapCmpt();
     const worldMap = worldMapCmpt.data;
-    worldMap.tectonics = generateTectonics(18, 800, 400);
+    worldMap.tectonics = generateTectonics(numPlates, xSize, ySize);
     worldMap.dataLayers[WorldMap.Layer.Elevation] = rasterizeTectonics(worldMap.tectonics);
     lowFreqNoise(worldMap.dataLayers[WorldMap.Layer.Elevation]);
     worldMapMgr.add(worldMapEntity, worldMapCmpt);

--- a/src/6-ui-features/CharacterCreationScene/characterCreationSlice.tsx
+++ b/src/6-ui-features/CharacterCreationScene/characterCreationSlice.tsx
@@ -174,7 +174,9 @@ export default characterCreationSlice.reducer;
 
 export const createPlayerCharacter = (): AppThunk => async (dispatch, getState) => {
   // This is temporary, we'll make a world gen area later.
-  await apiClient.emit(createWorldMap());
+  // Recommended settings: numPlates: 18, size: {x: 800, y: 400}
+  // Smaller settings for tests
+  await apiClient.emit(createWorldMap({ numPlates: 10, size: { x: 200, y: 100 } }));
 
   const {
     characterCreation: { characterAttributeGroups: cags },

--- a/src/6-ui-features/CharacterCreationScene/characterCreationSlice.tsx
+++ b/src/6-ui-features/CharacterCreationScene/characterCreationSlice.tsx
@@ -5,6 +5,7 @@ import apiClient from '3-frontend-api/ApiClient';
 import { getTowns } from '3-frontend-api/town';
 import { getPlayerId } from '3-frontend-api';
 import { createCharacter } from '1-game-code/CharacterCreation/CharacterCreationSys';
+import { createWorldMap } from '1-game-code/World/TerrainGen/TerrainGenSys';
 import { initialCharacterAttributeGroups } from './characterCreationData';
 import CharacterAttributeGroup, {
   PointAllocation,
@@ -172,6 +173,9 @@ export const {
 export default characterCreationSlice.reducer;
 
 export const createPlayerCharacter = (): AppThunk => async (dispatch, getState) => {
+  // This is temporary, we'll make a world gen area later.
+  await apiClient.emit(createWorldMap());
+
   const {
     characterCreation: { characterAttributeGroups: cags },
   } = getState();

--- a/src/6-ui-features/CharacterCreationScene/index.tsx
+++ b/src/6-ui-features/CharacterCreationScene/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import styled from '@emotion/styled';
 import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from '7-app/types';
+import TopBar from '6-ui-features/TopBar';
 import CharacterCreationNavBar from './CharacterCreationNavBar';
 import InfoWindow from './components/InfoWindow';
 import ScreenInfoToScreen from './components/ScreenInfoToScreen';
@@ -25,14 +26,17 @@ export default function CharacterCreationScene(): JSX.Element {
   }, [dispatch]);
 
   return (
-    <Container>
-      <CharacterCreationNavBar />
-      <Content>
-        <ScreenInfoToScreen screenInfo={screenInfo} />
-        <CharacterSummaryColumn />
-        <InfoWindow />
-      </Content>
-    </Container>
+    <>
+      <TopBar />
+      <Container>
+        <CharacterCreationNavBar />
+        <Content>
+          <ScreenInfoToScreen screenInfo={screenInfo} />
+          <CharacterSummaryColumn />
+          <InfoWindow />
+        </Content>
+      </Container>
+    </>
   );
 }
 

--- a/src/6-ui-features/ColosseumScene/index.tsx
+++ b/src/6-ui-features/ColosseumScene/index.tsx
@@ -5,6 +5,7 @@ import { useSelector as useReduxSelector } from 'react-redux';
 import { useSelector } from '4-react-ecsal';
 import { Canvas } from 'react-three-fiber';
 import { getUnitPosition } from '3-frontend-api';
+import TopBar from '6-ui-features/TopBar';
 import Ground from './Ground';
 import Unit from './Unit';
 import ActionBar from './ActionBar';
@@ -16,17 +17,20 @@ export default function ColosseumScene(): JSX.Element {
   const playerPosition: [number, number, number] = [x, y, 0];
 
   return (
-    <Container>
-      <Canvas>
-        <Ground position={[0, 0, -1]} />
-        <ambientLight />
-        <pointLight position={[10, 10, 10]} />
-        <Unit position={playerPosition} />
-        <Unit position={[1.2, 0, 0]} color="red" />
-        <Unit position={[4.2, 0, 0]} color="red" />
-      </Canvas>
-      <ActionBar />
-    </Container>
+    <>
+      <TopBar />
+      <Container>
+        <Canvas>
+          <Ground position={[0, 0, -1]} />
+          <ambientLight />
+          <pointLight position={[10, 10, 10]} />
+          <Unit position={playerPosition} />
+          <Unit position={[1.2, 0, 0]} color="red" />
+          <Unit position={[4.2, 0, 0]} color="red" />
+        </Canvas>
+        <ActionBar />
+      </Container>
+    </>
   );
 }
 

--- a/src/6-ui-features/TownScene/index.tsx
+++ b/src/6-ui-features/TownScene/index.tsx
@@ -4,6 +4,7 @@ import { useSelector as useReduxSelector, useDispatch } from 'react-redux';
 import { useSelector } from '4-react-ecsal';
 import { RootState } from '7-app/types';
 import { getTown } from '3-frontend-api';
+import TopBar from '6-ui-features/TopBar';
 import TownLocation from '../TownLocation';
 import PartySummary from './PartySummary';
 import { changedTitle } from '../TopBar/topBarSlice';
@@ -28,16 +29,19 @@ export default function TownScene(): JSX.Element {
   }
 
   return (
-    <Container>
-      <MainContent>
-        <PartySummary />
-        <LocationContainer>
-          {townLocationIds.map((townLocationId) => (
-            <TownLocation key={townLocationId} townLocationId={townLocationId} />
-          ))}
-        </LocationContainer>
-      </MainContent>
-    </Container>
+    <>
+      <TopBar />
+      <Container>
+        <MainContent>
+          <PartySummary />
+          <LocationContainer>
+            {townLocationIds.map((townLocationId) => (
+              <TownLocation key={townLocationId} townLocationId={townLocationId} />
+            ))}
+          </LocationContainer>
+        </MainContent>
+      </Container>
+    </>
   );
 }
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -11,5 +11,5 @@ test('renders learn react link', () => {
     </Provider>,
   );
 
-  expect(getByText(/map/i)).toBeInTheDocument();
+  expect(getByText(/Adventurer's Life/i)).toBeInTheDocument();
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,6 @@ import { Provider as EcsalProvider } from '4-react-ecsal';
 import MainMenuScene from '6-ui-features/MainMenuScene';
 import ColosseumScene from '6-ui-features/ColosseumScene';
 import WorldGenScene from '6-ui-features/WorldGenScene';
-import TopBar from './6-ui-features/TopBar';
 import { Scene } from './6-ui-features/sceneManager/sceneMetaSlice';
 
 import TownScene from './6-ui-features/TownScene';
@@ -37,7 +36,6 @@ function App(): JSX.Element {
   return (
     <EcsalProvider store={GameManager.instance.eMgr}>
       <Container>
-        <TopBar />
         <SceneComponent />
       </Container>
     </EcsalProvider>


### PR DESCRIPTION
Creating the world map on app start was creating issues in tests.
Moved it out to game start and removed the top bar from the main menu.

Fixes: nmkataoka/adv-life#308

## Checklist

- [x] PR is of reasonable size
