### PR TITLE
Add box blur and tweak noise parameters for fault perturbation

### DIFF
--- a/src/1-game-code/World/DataLayer/DataLayer.ts
+++ b/src/1-game-code/World/DataLayer/DataLayer.ts
@@ -7,11 +7,14 @@ export class DataLayer {
 
   metersPerCoord: number;
 
-  constructor(width: number, height: number, metersPerCoord = 25000) {
+  isCylindrical: boolean;
+
+  constructor(width: number, height: number, metersPerCoord = 25000, isCylindridal = true) {
     this.height = height;
     this.width = width;
     this.data = new Float32Array(width * height);
     this.metersPerCoord = metersPerCoord;
+    this.isCylindrical = isCylindridal;
   }
 
   /** Safe access, but slow */

--- a/src/1-game-code/World/DataLayer/boxBlur.ts
+++ b/src/1-game-code/World/DataLayer/boxBlur.ts
@@ -1,0 +1,50 @@
+import { RingQueue } from '8-helpers/containers/RingQueue';
+import { DataLayer } from './DataLayer';
+
+export function boxBlur(dataLayer: DataLayer, pixels: number): void {
+  // Box blur is amazing because horizontal and vertical blurring can be
+  // conducted independently.
+
+  const { width, height, isCylindrical } = dataLayer;
+  if (!isCylindrical) {
+    throw new Error('Non-cylindrical behavior not implemented');
+  }
+
+  // Horizontal blur
+  for (let yi = 0; yi < height; ++yi) {
+    let dataSum = 0;
+    const dataQueue = new RingQueue<number>();
+    for (let start = 0; start < 2 * pixels; ++start) {
+      const datum = dataLayer.at(start, yi);
+      dataSum += datum;
+      dataQueue.push(datum);
+    }
+    for (let xi = pixels; xi < width + pixels; ++xi) {
+      const datum = dataLayer.at(xi + pixels, yi);
+      dataSum += datum;
+      dataQueue.push(datum);
+
+      dataLayer.set(xi, yi, dataSum / (2 * pixels + 1));
+      dataSum -= dataQueue.pop();
+    }
+  }
+
+  // Vertical blur
+  for (let xi = 0; xi < width; ++xi) {
+    let dataSum = 0;
+    const dataQueue = new RingQueue<number>();
+    for (let start = 0; start < 2 * pixels; ++start) {
+      const datum = dataLayer.at(xi, start);
+      dataSum += datum;
+      dataQueue.push(datum);
+    }
+    for (let yi = pixels; yi < height - pixels; ++yi) {
+      const datum = dataLayer.at(xi, yi + pixels);
+      dataSum += datum;
+      dataQueue.push(datum);
+
+      dataLayer.set(xi, yi, dataSum / (2 * pixels + 1));
+      dataSum -= dataQueue.pop();
+    }
+  }
+}

--- a/src/1-game-code/World/TerrainGen/TerrainGenSys.ts
+++ b/src/1-game-code/World/TerrainGen/TerrainGenSys.ts
@@ -5,6 +5,7 @@ import { createRandomTerrain } from './elevationNoise/createRandomTerrain';
 import { generateTectonics } from './tectonicGeneration';
 import { rasterizeTectonics } from './tectonicRasterization';
 import { lowFreqNoise } from './elevationNoise/elevationNoise';
+import { boxBlur } from '../DataLayer/boxBlur';
 
 /** This is mostly just for debugging now, or if the real world map breaks for an extended period of time. */
 const createNoisedWorldMapSlice = createEventSlice('createNoisedWorldMap', {
@@ -48,6 +49,7 @@ const createWorldMapSlice = createEventSlice('createWorldMap', {
     const worldMap = worldMapCmpt.data;
     worldMap.tectonics = generateTectonics(numPlates, xSize, ySize);
     worldMap.dataLayers[WorldMap.Layer.Elevation] = rasterizeTectonics(worldMap.tectonics);
+    boxBlur(worldMap.dataLayers[WorldMap.Layer.Elevation], 2);
     lowFreqNoise(worldMap.dataLayers[WorldMap.Layer.Elevation]);
     worldMapMgr.add(worldMapEntity, worldMapCmpt);
   },

--- a/src/1-game-code/World/TerrainGen/elevationNoise/createRandomTerrain.ts
+++ b/src/1-game-code/World/TerrainGen/elevationNoise/createRandomTerrain.ts
@@ -1,5 +1,5 @@
 import SimplexNoise from '10-simplex-noise';
-import { DataLayer } from '../../DataLayer';
+import { DataLayer } from '../../DataLayer/DataLayer';
 
 /** Drop in replacement for the entire terrain generation system,
  * mostly for debugging.

--- a/src/1-game-code/World/TerrainGen/elevationNoise/elevationNoise.ts
+++ b/src/1-game-code/World/TerrainGen/elevationNoise/elevationNoise.ts
@@ -1,5 +1,5 @@
 import SimplexNoise from '10-simplex-noise';
-import { DataLayer } from '../../DataLayer';
+import { DataLayer } from '../../DataLayer/DataLayer';
 
 /** For some reason, this noise generator seems to have a tendency to eat
  * away at landmasses, so I added this bias to shift the noise up.

--- a/src/1-game-code/World/TerrainGen/tectonicGeneration/perturbPlateEdges.ts
+++ b/src/1-game-code/World/TerrainGen/tectonicGeneration/perturbPlateEdges.ts
@@ -4,8 +4,8 @@ import { Fault } from '../Fault';
 
 export function perturbPlateEdges(faults: Fault[], metersPerCoord: number): void {
   // Perturb edges into natural-looking faults that scale with world-size
-  const segmentLength = Math.floor(metersPerCoord / 15000);
-  const faultNoiseScaling = 50000000 / metersPerCoord;
+  const segmentLength = Math.floor(metersPerCoord / 10000);
+  const faultNoiseScaling = 10000000 / metersPerCoord;
 
   faults.forEach((fault) => {
     // Calculate edge unit-slope and its perpendicular
@@ -19,8 +19,8 @@ export function perturbPlateEdges(faults: Fault[], metersPerCoord: number): void
 
     // These settings control how the faults look
     const noise = new SimplexNoise('test', {
-      frequency: 9.2 * 10 ** -10 * metersPerCoord,
-      octaves: 4,
+      frequency: 80 * 10 ** -10 * metersPerCoord,
+      octaves: 10,
       lacunarity: 1.85,
       gain: 0.53,
     });

--- a/src/1-game-code/World/TerrainGen/tectonicRasterization/fillInHoles.test.ts
+++ b/src/1-game-code/World/TerrainGen/tectonicRasterization/fillInHoles.test.ts
@@ -1,4 +1,4 @@
-import { DataLayer } from '../../DataLayer';
+import { DataLayer } from '../../DataLayer/DataLayer';
 import { findMostCommonElevationOnHoleBorder } from './fillInHoles';
 
 describe('fillInHoles', () => {

--- a/src/1-game-code/World/TerrainGen/tectonicRasterization/fillInHoles.ts
+++ b/src/1-game-code/World/TerrainGen/tectonicRasterization/fillInHoles.ts
@@ -1,7 +1,7 @@
 import { initializeArrayWithValue } from '8-helpers/ArrayExtensions';
 import { RingQueue } from '8-helpers/containers/RingQueue';
 import { Vector2 } from '8-helpers/math';
-import { DataLayer } from '../../DataLayer';
+import { DataLayer } from '../../DataLayer/DataLayer';
 
 export function fillInHoles(elevLayer: DataLayer, numPlates: number): void {
   let allFilled = true;

--- a/src/1-game-code/World/TerrainGen/tectonicRasterization/floodfillFromFault.ts
+++ b/src/1-game-code/World/TerrainGen/tectonicRasterization/floodfillFromFault.ts
@@ -2,7 +2,7 @@ import { initializeArrayWithValue, shuffle } from '8-helpers/ArrayExtensions';
 import { RingQueue } from '8-helpers/containers/RingQueue';
 import { Vector2 } from '8-helpers/math';
 import { add, dist, multiply } from '8-helpers/math/Vector2';
-import { DataLayer } from '../../DataLayer';
+import { DataLayer } from '../../DataLayer/DataLayer';
 import { Fault } from '../Fault';
 import { simpleBresenham } from './simpleBresenham';
 

--- a/src/1-game-code/World/TerrainGen/tectonicRasterization/propagateElevationsFromFaults.ts
+++ b/src/1-game-code/World/TerrainGen/tectonicRasterization/propagateElevationsFromFaults.ts
@@ -1,4 +1,4 @@
-import { DataLayer } from '1-game-code/World/DataLayer';
+import { DataLayer } from '1-game-code/World/DataLayer/DataLayer';
 import { Vector2 } from '8-helpers/math';
 import { multiply } from '8-helpers/math/Vector2';
 import { convergence, Fault, hasSamePlateTypes, MAX_CONVERGENCE } from '../Fault';

--- a/src/1-game-code/World/TerrainGen/tectonicRasterization/rasterizeFaults.ts
+++ b/src/1-game-code/World/TerrainGen/tectonicRasterization/rasterizeFaults.ts
@@ -1,5 +1,5 @@
 import { multiply } from '8-helpers/math/Vector2';
-import { DataLayer } from '../../DataLayer';
+import { DataLayer } from '../../DataLayer/DataLayer';
 import { getBaseElevation } from '../TecPlate';
 import { simpleBresenham } from './simpleBresenham';
 import { Fault } from '../Fault';

--- a/src/1-game-code/World/TerrainGen/tectonicRasterization/rasterizeTecPlates.ts
+++ b/src/1-game-code/World/TerrainGen/tectonicRasterization/rasterizeTecPlates.ts
@@ -1,5 +1,5 @@
 import { fillInHoles } from './fillInHoles';
-import { DataLayer } from '../../DataLayer';
+import { DataLayer } from '../../DataLayer/DataLayer';
 import { TecPlate } from '../TecPlate';
 import { shapeCoasts } from './shapeCoasts';
 import { Tectonics } from '../Tectonics';

--- a/src/1-game-code/World/TerrainGen/tectonicRasterization/shapeCoasts.ts
+++ b/src/1-game-code/World/TerrainGen/tectonicRasterization/shapeCoasts.ts
@@ -1,7 +1,7 @@
 import { initializeArrayWithValue } from '8-helpers/ArrayExtensions';
 import { RingQueue } from '8-helpers/containers/RingQueue';
 import { toVec2i, Vector2 } from '8-helpers/math/Vector2';
-import { DataLayer } from '../../DataLayer';
+import { DataLayer } from '../../DataLayer/DataLayer';
 import { Fault } from '../Fault';
 import { floodfillFromFault } from './floodfillFromFault';
 import { TecPlate } from '../TecPlate';

--- a/src/1-game-code/World/WorldMap.ts
+++ b/src/1-game-code/World/WorldMap.ts
@@ -1,4 +1,4 @@
-import { DataLayer } from './DataLayer';
+import { DataLayer } from './DataLayer/DataLayer';
 import { defaultTectonics, Tectonics } from './TerrainGen/Tectonics';
 
 export class WorldMap {

--- a/src/1-game-code/World/index.ts
+++ b/src/1-game-code/World/index.ts
@@ -1,1 +1,1 @@
-export { DataLayer } from './DataLayer';
+export { DataLayer } from './DataLayer/DataLayer';

--- a/src/6-ui-features/CharacterCreationScene/characterCreationSlice.tsx
+++ b/src/6-ui-features/CharacterCreationScene/characterCreationSlice.tsx
@@ -175,6 +175,8 @@ export default characterCreationSlice.reducer;
 export const createPlayerCharacter = (): AppThunk => async (dispatch, getState) => {
   // This is temporary, we'll make a world gen area later.
   // Recommended settings: numPlates: 18, size: {x: 800, y: 400}
+  // await apiClient.emit(createWorldMap({ numPlates: 18, size: { x: 800, y: 400 } }));
+
   // Smaller settings for tests
   await apiClient.emit(createWorldMap({ numPlates: 10, size: { x: 200, y: 100 } }));
 


### PR DESCRIPTION
The noise parameters are not really set up properly to handle changing
the metersPerCoord property, so they needed to be tweaked since
the port involved changing meters per coord from 50k to 25k. When we
reduce to 4k, will need to do heavy tweaking on each terrain gen step
again.

Fixes: nmkataoka/adv-life#305

## Checklist

- [x] PR is of reasonable size
