### PR TITLE
Port ridge noise & hilliness, tweak terrain gen params

### DIFF
--- a/src/1-game-code/World/DataLayer/DataLayer.ts
+++ b/src/1-game-code/World/DataLayer/DataLayer.ts
@@ -5,11 +5,20 @@ export class DataLayer {
 
   width: number;
 
+  name: string;
+
   metersPerCoord: number;
 
   isCylindrical: boolean;
 
-  constructor(width: number, height: number, metersPerCoord = 25000, isCylindridal = true) {
+  constructor(
+    name: string,
+    width: number,
+    height: number,
+    metersPerCoord = 25000,
+    isCylindridal = true,
+  ) {
+    this.name = name;
     this.height = height;
     this.width = width;
     this.data = new Float32Array(width * height);

--- a/src/1-game-code/World/TerrainGen/elevationNoise/createRandomTerrain.ts
+++ b/src/1-game-code/World/TerrainGen/elevationNoise/createRandomTerrain.ts
@@ -1,3 +1,4 @@
+import { WorldMap } from '1-game-code/World/WorldMap';
 import SimplexNoise from '10-simplex-noise';
 import { DataLayer } from '../../DataLayer/DataLayer';
 
@@ -5,7 +6,7 @@ import { DataLayer } from '../../DataLayer/DataLayer';
  * mostly for debugging.
  */
 export function createRandomTerrain(): DataLayer {
-  const elevations = new DataLayer(400, 300);
+  const elevations = new DataLayer(WorldMap.Layer.Elevation, 400, 300);
   const simplex = new SimplexNoise('seed', { frequency: 0.005, octaves: 8 });
   for (let y = 0; y < elevations.height; ++y) {
     for (let x = 0; x < elevations.width; ++x) {

--- a/src/1-game-code/World/TerrainGen/elevationNoise/elevationNoise.ts
+++ b/src/1-game-code/World/TerrainGen/elevationNoise/elevationNoise.ts
@@ -4,9 +4,9 @@ import { DataLayer } from '../../DataLayer/DataLayer';
 /** For some reason, this noise generator seems to have a tendency to eat
  * away at landmasses, so I added this bias to shift the noise up.
  */
-const landBias = -0.1;
+const landBias = 0.1;
 
-const scaling = 10000;
+const scaling = 2000;
 
 /** This noise generator is primarily made to break up the artificial fault lines.
  * It is not affected by hilliness.

--- a/src/1-game-code/World/TerrainGen/elevationNoise/ridgeNoise.ts
+++ b/src/1-game-code/World/TerrainGen/elevationNoise/ridgeNoise.ts
@@ -1,0 +1,24 @@
+import { DataLayer } from '1-game-code/World/DataLayer/DataLayer';
+import SimplexNoise from '10-simplex-noise';
+
+// Full upward bias, we're only interested in adding mountains not subtracing them
+const landBias = 0.95;
+
+export function ridgeNoise(elevLayer: DataLayer, hillinessLayer: DataLayer): void {
+  // TODO: this noise should be shifted to 3D and wrap around for cylindrical maps
+  const { height, width, metersPerCoord } = elevLayer;
+  const noise = new SimplexNoise('test', {
+    frequency: 5 * 10 ** -7 * metersPerCoord,
+    octaves: 10,
+    lacunarity: 2,
+    gain: 0.55,
+  });
+
+  for (let yi = 0; yi < height; ++yi) {
+    for (let xi = 0; xi < width; ++xi) {
+      const hilliness = hillinessLayer.at(xi, yi);
+      const elev = elevLayer.at(xi, yi);
+      elevLayer.set(xi, yi, elev + (hilliness * noise.noise2D(xi, yi) + landBias));
+    }
+  }
+}

--- a/src/1-game-code/World/TerrainGen/tectonicRasterization/constants.ts
+++ b/src/1-game-code/World/TerrainGen/tectonicRasterization/constants.ts
@@ -1,0 +1,3 @@
+export const defaultHilliness = 1;
+export const mountainHilliness = 5000;
+export const hillHilliness = 3000;

--- a/src/1-game-code/World/TerrainGen/tectonicRasterization/fillInHoles.test.ts
+++ b/src/1-game-code/World/TerrainGen/tectonicRasterization/fillInHoles.test.ts
@@ -1,3 +1,4 @@
+import { WorldMap } from '1-game-code/World/WorldMap';
 import { DataLayer } from '../../DataLayer/DataLayer';
 import { findMostCommonElevationOnHoleBorder } from './fillInHoles';
 
@@ -5,7 +6,7 @@ describe('fillInHoles', () => {
   const empty = -11000000;
   describe('findMostCommonElevationOnHoleBorder', () => {
     it('finds correct elevation in simple case', () => {
-      const map = new DataLayer(3, 3);
+      const map = new DataLayer(WorldMap.Layer.Elevation, 3, 3);
       const data = [
         [1, 1, 1],
         [2, empty, 2],
@@ -23,7 +24,7 @@ describe('fillInHoles', () => {
         [0, empty, empty, 0],
         [3, 1, empty, 3],
       ];
-      const map = new DataLayer(4, 4);
+      const map = new DataLayer(WorldMap.Layer.Elevation, 4, 4);
       data.forEach((row, rowIdx) => row.forEach((el, colIdx) => map.set(rowIdx, colIdx, el)));
       const mostCommonElev = findMostCommonElevationOnHoleBorder(map, { x: 1, y: 2 }, 2);
       expect(mostCommonElev).toEqual(3);

--- a/src/1-game-code/World/TerrainGen/tectonicRasterization/rasterizeTecPlates.ts
+++ b/src/1-game-code/World/TerrainGen/tectonicRasterization/rasterizeTecPlates.ts
@@ -1,3 +1,4 @@
+import { WorldMap } from '1-game-code/World/WorldMap';
 import { fillInHoles } from './fillInHoles';
 import { DataLayer } from '../../DataLayer/DataLayer';
 import { TecPlate } from '../TecPlate';
@@ -5,23 +6,27 @@ import { shapeCoasts } from './shapeCoasts';
 import { Tectonics } from '../Tectonics';
 import { rasterizeFaults } from './rasterizeFaults';
 import { propagateElevationsFromFaults } from './propagateElevationsFromFaults';
+import { defaultHilliness } from './constants';
 
 export function rasterizeTectonics(
   { height, width, numPlates, faults, tecPlates }: Tectonics,
   debug = false,
-): DataLayer {
-  const elevLayer = new DataLayer(width, height);
+): { elevLayer: DataLayer; hillinessLayer: DataLayer } {
+  const elevLayer = new DataLayer(WorldMap.Layer.Elevation, width, height);
   // Note that default uninitialized value is 11 million
   elevLayer.setAll(-11000000);
   rasterizeFaults(elevLayer, faults);
   fillInHoles(elevLayer, numPlates);
   shapeCoasts(elevLayer, faults, tecPlates);
-  propagateElevationsFromFaults(elevLayer, faults);
+
+  const hillinessLayer = new DataLayer(WorldMap.Layer.Hilliness, width, height);
+  hillinessLayer.setAll(defaultHilliness);
+  propagateElevationsFromFaults(elevLayer, hillinessLayer, faults);
 
   if (debug) {
     debugTecPlates(elevLayer, tecPlates);
   }
-  return elevLayer;
+  return { elevLayer, hillinessLayer };
 }
 
 /** Draws the tec plate centers onto the map */

--- a/src/1-game-code/World/WorldMap.ts
+++ b/src/1-game-code/World/WorldMap.ts
@@ -4,6 +4,7 @@ import { defaultTectonics, Tectonics } from './TerrainGen/Tectonics';
 export class WorldMap {
   static Layer = {
     Elevation: 'elevation',
+    Hilliness: 'hilliness',
   } as const;
 
   dataLayers: { [key: string]: DataLayer } = {};

--- a/src/6-ui-features/CharacterCreationScene/characterCreationSlice.tsx
+++ b/src/6-ui-features/CharacterCreationScene/characterCreationSlice.tsx
@@ -5,7 +5,6 @@ import apiClient from '3-frontend-api/ApiClient';
 import { getTowns } from '3-frontend-api/town';
 import { getPlayerId } from '3-frontend-api';
 import { createCharacter } from '1-game-code/CharacterCreation/CharacterCreationSys';
-import { createWorldMap } from '1-game-code/World/TerrainGen/TerrainGenSys';
 import { initialCharacterAttributeGroups } from './characterCreationData';
 import CharacterAttributeGroup, {
   PointAllocation,
@@ -173,13 +172,6 @@ export const {
 export default characterCreationSlice.reducer;
 
 export const createPlayerCharacter = (): AppThunk => async (dispatch, getState) => {
-  // This is temporary, we'll make a world gen area later.
-  // Recommended settings: numPlates: 18, size: {x: 800, y: 400}
-  // await apiClient.emit(createWorldMap({ numPlates: 18, size: { x: 800, y: 400 } }));
-
-  // Smaller settings for tests
-  await apiClient.emit(createWorldMap({ numPlates: 10, size: { x: 200, y: 100 } }));
-
   const {
     characterCreation: { characterAttributeGroups: cags },
   } = getState();

--- a/src/6-ui-features/MainMenuScene/index.tsx
+++ b/src/6-ui-features/MainMenuScene/index.tsx
@@ -3,11 +3,20 @@ import styled from '@emotion/styled';
 import { changedScene, Scene } from '6-ui-features/sceneManager/sceneMetaSlice';
 import { useDispatch } from 'react-redux';
 import { createPlayerCharacter } from '6-ui-features/CharacterCreationScene/characterCreationSlice';
+import { startWorldGen } from '6-ui-features/WorldGenScene/actions';
+import { useIsTest } from '6-ui-features/TestContext';
 
 export default function MainMenuScene(): JSX.Element {
   const dispatch = useDispatch();
+  const isTest = useIsTest();
   const handleSceneSelection = (scene: Scene) => () => {
     if (scene === Scene.Colosseum) {
+      if (isTest) {
+        dispatch(startWorldGen({ numPlates: 10, size: { x: 200, y: 100 } }));
+      } else {
+        dispatch(startWorldGen({ numPlates: 12, size: { x: 800, y: 400 } }));
+      }
+
       dispatch(createPlayerCharacter());
     }
     dispatch(changedScene(scene));

--- a/src/6-ui-features/TestContext/index.ts
+++ b/src/6-ui-features/TestContext/index.ts
@@ -1,0 +1,10 @@
+import { useContext, createContext } from 'react';
+
+const TestContext = createContext(false);
+
+export const TestProvider = TestContext.Provider;
+
+export function useIsTest(): boolean {
+  const isTest = useContext(TestContext);
+  return isTest;
+}

--- a/src/6-ui-features/WorldGenScene/actions.ts
+++ b/src/6-ui-features/WorldGenScene/actions.ts
@@ -1,0 +1,15 @@
+import { createWorldMap } from '1-game-code/World/TerrainGen/TerrainGenSys';
+import { AppThunk } from '7-app/types';
+import apiClient from '3-frontend-api/ApiClient';
+
+export const startWorldGen = (payload: {
+  numPlates: number;
+  size: { x: number; y: number };
+}): AppThunk => async () => {
+  // This is temporary, we'll make a world gen area later.
+  // Recommended settings
+  // await apiClient.emit(createWorldMap({ numPlates: 12, size: { x: 800, y: 400 } }));
+
+  // Smaller settings for tests
+  await apiClient.emit(createWorldMap(payload));
+};

--- a/src/6-ui-features/WorldMap/PixelMap.test.ts
+++ b/src/6-ui-features/WorldMap/PixelMap.test.ts
@@ -1,4 +1,5 @@
 import { DataLayer } from '1-game-code/World';
+import { WorldMap } from '1-game-code/World/WorldMap';
 import { Color } from './Color';
 import PixelMap from './PixelMap';
 
@@ -38,7 +39,7 @@ describe('PixelMap', () => {
     global.ImageData = originalImageData;
   });
   it('outputs correct colors for simple map', () => {
-    const elevs = new DataLayer(2, 2);
+    const elevs = new DataLayer(WorldMap.Layer.Elevation, 2, 2);
     elevs.set(1, 0, 1);
     elevs.set(0, 1, 2);
     elevs.set(1, 1, 3);

--- a/src/6-ui-features/WorldMap/PixelMap.ts
+++ b/src/6-ui-features/WorldMap/PixelMap.ts
@@ -96,7 +96,7 @@ export default class PixelMap {
  * Uses interpolation, so there is loss of data at map edges.
  */
 function shearElevs(map: DataLayer, shearFrac = 0.004): DataLayer {
-  const output = new DataLayer(map.width, map.height);
+  const output = new DataLayer('shearedElevations', map.width, map.height);
   output.setAll(-1000000);
   /**
    *

--- a/src/6-ui-features/WorldMap/WorldMapCanvas.tsx
+++ b/src/6-ui-features/WorldMap/WorldMapCanvas.tsx
@@ -13,9 +13,11 @@ const colors: Color[] = [
   [0, 55, 120, 255],
   [0, 119, 190, 255],
   [137, 207, 245, 255],
-  [155, 177, 125, 255],
   [200, 198, 164, 255],
-  [220, 230, 220, 220],
+  [155, 177, 125, 255],
+  // [220, 230, 220, 220],
+  [119, 119, 119, 255],
+  [238, 238, 238, 238],
 ];
 
 function colorElevation(elev: number): Color {
@@ -34,10 +36,13 @@ function colorElevation(elev: number): Color {
   if (elev < 2000) {
     return colorInterp(elev, 0, 2000, colors[4], colors[5]);
   }
-  if (elev < 9000) {
-    return colorInterp(elev, 2000, 9000, colors[5], colors[6]);
+  if (elev < 4000) {
+    return colorInterp(elev, 2000, 4000, colors[5], colors[6]);
   }
-  return colors[6];
+  if (elev < 8000) {
+    return colorInterp(elev, 4000, 8000, colors[6], colors[7]);
+  }
+  return colors[7];
 }
 
 type WorldMapCanvasProps = {

--- a/src/7-app/tests/buyItems.integration.test.tsx
+++ b/src/7-app/tests/buyItems.integration.test.tsx
@@ -5,7 +5,7 @@ import App from '../../App';
 
 describe('buy items (integration)', () => {
   it('can create character and buy items', async () => {
-    const { getByText, getByRole } = render(<App />);
+    const { getByText, getByRole } = render(<App isTest />);
 
     const closeModal = () => {
       const closeButton = getByRole('button', { name: 'X' });

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -7,7 +7,7 @@ import App from './App';
 test('renders learn react link', () => {
   const { getByText } = render(
     <Provider store={store}>
-      <App />
+      <App isTest />
     </Provider>,
   );
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { Provider as EcsalProvider } from '4-react-ecsal';
 import MainMenuScene from '6-ui-features/MainMenuScene';
 import ColosseumScene from '6-ui-features/ColosseumScene';
 import WorldGenScene from '6-ui-features/WorldGenScene';
+import { TestProvider } from '6-ui-features/TestContext';
 import { Scene } from './6-ui-features/sceneManager/sceneMetaSlice';
 
 import TownScene from './6-ui-features/TownScene';
@@ -22,7 +23,11 @@ const scenes = {
   [Scene.WorldGen]: WorldGenScene,
 };
 
-function App(): JSX.Element {
+type AppProps = {
+  isTest?: boolean;
+};
+
+function App({ isTest = false }: AppProps): JSX.Element {
   useEffect(() => {
     void GameManager.instance.Start();
 
@@ -34,11 +39,13 @@ function App(): JSX.Element {
   const SceneComponent = scenes[currentScene];
 
   return (
-    <EcsalProvider store={GameManager.instance.eMgr}>
-      <Container>
-        <SceneComponent />
-      </Container>
-    </EcsalProvider>
+    <TestProvider value={isTest}>
+      <EcsalProvider store={GameManager.instance.eMgr}>
+        <Container>
+          <SceneComponent />
+        </Container>
+      </EcsalProvider>
+    </TestProvider>
   );
 }
 


### PR DESCRIPTION
- Ported ridge noise & hilliness
- Tweaked terrain gen params to reduce reliance on noise, simplify
  some of the fault profile logic (ridge width is no longer a param but
  calculated from existing properties)
- Fixed an issue with fault features that were wider than they were long
  (they were having trouble fitting onto the map)
- Also set up a TestContext to trigger lower resolution simulation for
  tests (for the integration tests where the simulation isn't the point)

Fixes: nmkataoka/adv-life#307

## Checklist

- [x] PR is of reasonable size
