### PR TITLE
Update world gen setting sliders to show current value

### DIFF
--- a/src/6-ui-features/WorldGenScene/Sidebar/SliderOptions.tsx
+++ b/src/6-ui-features/WorldGenScene/Sidebar/SliderOptions.tsx
@@ -27,18 +27,13 @@ function SliderOption({ name, value, min, max, step, onChange }: SliderOptionPro
   return (
     <tr>
       <td>{name}</td>
-      <MinCell>{toDisplay(min)}</MinCell>
       <td>
         <input type="range" min={min} max={max} step={step} onChange={onChange} value={value} />
       </td>
-      <td>{toDisplay(max)}</td>
+      <td>{toDisplay(value)}</td>
     </tr>
   );
 }
-
-const MinCell = styled.td`
-  text-align: right;
-`;
 
 export type SliderOptionsProps = {
   options: Omit<SliderOptionProps, 'onChange'>[];
@@ -50,7 +45,6 @@ export function SliderOptions({ options, onChange }: SliderOptionsProps): JSX.El
     <Table>
       <colgroup>
         <col span={1} style={{ width: 'auto' }} />
-        <col span={1} style={{ width: '5em' }} />
         <col span={1} style={{ width: '10em' }} />
         <col span={1} style={{ width: '5em' }} />
       </colgroup>

--- a/src/6-ui-features/WorldGenScene/Sidebar/constants/createNoiseSettings.ts
+++ b/src/6-ui-features/WorldGenScene/Sidebar/constants/createNoiseSettings.ts
@@ -29,7 +29,7 @@ export function createNoiseSettings(args: {
     description: 'More octaves means the noise is computed at higher resolution.',
     value: octaves,
     min: 1,
-    max: 12,
+    max: 16,
     step: 1,
   };
   const lacunaritySettings = {

--- a/src/6-ui-features/WorldGenScene/Sidebar/constants/terrainGenControls.ts
+++ b/src/6-ui-features/WorldGenScene/Sidebar/constants/terrainGenControls.ts
@@ -10,7 +10,7 @@ export const terrainGenControls: TabContentProps['content'] = [
         description: 'Map width in tiles. 1 tile = 4092 m.',
         value: 800,
         min: 100,
-        max: 1000,
+        max: 1600,
         step: 50,
       },
       {
@@ -18,7 +18,7 @@ export const terrainGenControls: TabContentProps['content'] = [
         description: 'Map height in tiles. 1 tile = 4092 m.',
         value: 400,
         min: 50,
-        max: 500,
+        max: 800,
         step: 50,
       },
       {


### PR DESCRIPTION
- Based on other sliders around the web, showing current value and not
  min/max seems standard and a lot better
- Also tweaked world gen param ranges

Fixes: nmkataoka/adv-life#329

## Checklist

- [x] PR is of reasonable size
