### PR TITLE
Hook up world gen ui to engine

### DIFF
--- a/src/0-engine/ECS/EntityManager.ts
+++ b/src/0-engine/ECS/EntityManager.ts
@@ -47,6 +47,13 @@ export class EntityManager {
     this.destroyQueuedEntities();
   }
 
+  // TODO: This should be coded as a dispatch default event
+  /** Warning! All unsaved anything will be lost */
+  public async restart(): Promise<void> {
+    this.cMgrs = {};
+    await this.Start();
+  }
+
   public registerEventListener<Payload, ComponentDependencies extends AbstractComponentClasses>(
     eventName: string,
     listener: EventListener<Payload, ComponentDependencies>,
@@ -186,6 +193,21 @@ export class EntityManager {
   public getUniqueCmptMut = <C extends NComponent>(cclass: NComponentConstructor<C>): C => {
     const cMgr = this.tryGetMgrMut<C>(cclass);
     return cMgr.getUniqueMut();
+  };
+
+  public tryGetUniqueCmpt = <C extends NComponent>(
+    cclass: NComponentConstructor<C>,
+  ): DeepReadonly<C> | undefined => {
+    const cMgr = this.tryGetMgr<C>(cclass);
+    return cMgr.tryGetUnique();
+  };
+
+  /** Gets a unique component if exists, mutable. */
+  public tryGetUniqueCmptMut = <C extends NComponent>(
+    cclass: NComponentConstructor<C>,
+  ): C | undefined => {
+    const cMgr = this.tryGetMgr<C>(cclass);
+    return cMgr.tryGetUniqueMut();
   };
 
   /** Creates a component, adds it to an entity, and returns it. */

--- a/src/0-engine/ECS/component-manager/ComponentManager.ts
+++ b/src/0-engine/ECS/component-manager/ComponentManager.ts
@@ -66,7 +66,14 @@ export class ComponentManager<C extends NComponent> {
   }
 
   /**
-   * No immutable version since you only need this if you're considering creating it.
+   * See getUnique
+   */
+  public tryGetUnique(): DeepReadonly<C> | undefined {
+    return this.getAsArray()[0];
+  }
+
+  /**
+   * See getUniqueMut
    */
   public tryGetUniqueMut(): C | undefined {
     return this.getAsArrayMut()[0];

--- a/src/0-engine/GameManager.ts
+++ b/src/0-engine/GameManager.ts
@@ -22,6 +22,10 @@ export class GameManager {
       window.gameManager = this;
     }
     this.eMgr = new EntityManager();
+    this.registerListeners();
+  }
+
+  private registerListeners(): void {
     eventListeners.forEach((listener) => {
       this.eMgr.registerEventListener(listener.eventType, listener);
     });

--- a/src/1-game-code/Noise/index.ts
+++ b/src/1-game-code/Noise/index.ts
@@ -1,0 +1,7 @@
+export type NoiseParams = {
+  scale: number;
+  frequency: number;
+  octaves: number;
+  lacunarity: number;
+  gain: number;
+};

--- a/src/1-game-code/World/TerrainGen/elevationNoise/elevationNoise.ts
+++ b/src/1-game-code/World/TerrainGen/elevationNoise/elevationNoise.ts
@@ -1,3 +1,4 @@
+import { NoiseParams } from '1-game-code/Noise';
 import SimplexNoise from '10-simplex-noise';
 import { DataLayer } from '../../DataLayer/DataLayer';
 
@@ -6,22 +7,21 @@ import { DataLayer } from '../../DataLayer/DataLayer';
  */
 const landBias = 0.1;
 
-const scaling = 2000;
-
 /** This noise generator is primarily made to break up the artificial fault lines.
  * It is not affected by hilliness.
  */
-export function lowFreqNoise(elevLayer: DataLayer): void {
-  const { metersPerCoord, width, height } = elevLayer;
+export function lowFreqNoise(elevLayer: DataLayer, noiseParams: NoiseParams): void {
+  const { width, height } = elevLayer;
+  const { scale, frequency, octaves, lacunarity, gain } = noiseParams;
   const noise = new SimplexNoise('test', {
-    frequency: 7.3 * 10 ** -7 * metersPerCoord,
-    octaves: 8,
-    lacunarity: 2.0,
-    gain: 0.5,
+    frequency,
+    octaves,
+    lacunarity,
+    gain,
   });
   for (let xi = 0; xi < width; ++xi) {
     for (let yi = 0; yi < height; ++yi) {
-      elevLayer.set(xi, yi, elevLayer.at(xi, yi) + scaling * (landBias + noise.noise2D(xi, yi)));
+      elevLayer.set(xi, yi, elevLayer.at(xi, yi) + scale * (landBias + noise.noise2D(xi, yi)));
     }
   }
 }

--- a/src/1-game-code/World/TerrainGen/elevationNoise/ridgeNoise.ts
+++ b/src/1-game-code/World/TerrainGen/elevationNoise/ridgeNoise.ts
@@ -1,17 +1,23 @@
+import { NoiseParams } from '1-game-code/Noise';
 import { DataLayer } from '1-game-code/World/DataLayer/DataLayer';
 import SimplexNoise from '10-simplex-noise';
 
 // Full upward bias, we're only interested in adding mountains not subtracing them
 const landBias = 0.95;
 
-export function ridgeNoise(elevLayer: DataLayer, hillinessLayer: DataLayer): void {
+export function ridgeNoise(
+  elevLayer: DataLayer,
+  hillinessLayer: DataLayer,
+  noiseParams: NoiseParams,
+): void {
   // TODO: this noise should be shifted to 3D and wrap around for cylindrical maps
-  const { height, width, metersPerCoord } = elevLayer;
+  const { height, width } = elevLayer;
+  const { frequency, octaves, lacunarity, gain } = noiseParams;
   const noise = new SimplexNoise('test', {
-    frequency: 3 * 10 ** -6 * metersPerCoord,
-    octaves: 10,
-    lacunarity: 2,
-    gain: 0.55,
+    frequency,
+    octaves,
+    lacunarity,
+    gain,
   });
 
   for (let yi = 0; yi < height; ++yi) {

--- a/src/1-game-code/World/TerrainGen/tectonicGeneration/createPlatesAndFaults.ts
+++ b/src/1-game-code/World/TerrainGen/tectonicGeneration/createPlatesAndFaults.ts
@@ -3,17 +3,17 @@ import { createFaultFromEdge, Fault } from '../Fault';
 import { TecPlate } from '../TecPlate';
 import { VoronoiDiagram } from '../Voronoi/Voronoi';
 
-const oceanFrac = 0.65;
 const PI = 2.1415926535;
 
 /** Creates tectonic plates (with placeholder properties) and faults and links them */
 export function createPlatesAndFaults(
   voronoi: VoronoiDiagram,
+  oceanFrac: number,
 ): { tecPlates: TecPlate[]; faults: Fault[] } {
   const { points, edges, xSize, isCylindrical } = voronoi;
 
   const tecPlates: TecPlate[] = points.map((point) => ({
-    ...randomizePlateProperties(),
+    ...randomizePlateProperties(oceanFrac),
     center: point,
     faults: [], // Placeholder
   }));
@@ -41,7 +41,7 @@ export function createPlatesAndFaults(
   return { faults, tecPlates };
 }
 
-function randomizePlateProperties(): Omit<TecPlate, 'center' | 'faults'> {
+function randomizePlateProperties(oceanFrac: number): Omit<TecPlate, 'center' | 'faults'> {
   return {
     age: Math.random(),
     isOceanic: Math.random() < oceanFrac,

--- a/src/1-game-code/World/TerrainGen/tectonicGeneration/generateTectonics.ts
+++ b/src/1-game-code/World/TerrainGen/tectonicGeneration/generateTectonics.ts
@@ -1,12 +1,19 @@
+import { NoiseParams } from '1-game-code/Noise';
 import { generateVoronoi } from '../Voronoi/Voronoi';
 import { Tectonics } from '../Tectonics';
 import { perturbPlateEdges } from './perturbPlateEdges';
 import { createPlatesAndFaults } from './createPlatesAndFaults';
 
-export function generateTectonics(numPlates: number, xSize: number, ySize: number): Tectonics {
+export function generateTectonics(
+  numPlates: number,
+  xSize: number,
+  ySize: number,
+  oceanFrac: number,
+  faultPerturbationNoise: NoiseParams,
+): Tectonics {
   const voronoi = generateVoronoi(numPlates, xSize, ySize, 3);
-  const { tecPlates, faults } = createPlatesAndFaults(voronoi);
-  perturbPlateEdges(faults, 25000);
+  const { tecPlates, faults } = createPlatesAndFaults(voronoi, oceanFrac);
+  perturbPlateEdges(faults, 25000, faultPerturbationNoise);
   return {
     faults,
     numPlates,

--- a/src/1-game-code/World/TerrainGen/tectonicGeneration/perturbPlateEdges.ts
+++ b/src/1-game-code/World/TerrainGen/tectonicGeneration/perturbPlateEdges.ts
@@ -1,13 +1,19 @@
+import { NoiseParams } from '1-game-code/Noise';
 import SimplexNoise from '10-simplex-noise';
 import { add, multiply, rotate, Vector2 } from '8-helpers/math/Vector2';
 import { Fault } from '../Fault';
 
-export function perturbPlateEdges(faults: Fault[], metersPerCoord: number): void {
+export function perturbPlateEdges(
+  faults: Fault[],
+  metersPerCoord: number,
+  noiseParams: NoiseParams,
+): void {
+  const { scale, frequency, octaves, lacunarity, gain } = noiseParams;
   // Perturb edges into natural-looking faults that scale with world-size
 
   /** Length of segments, in tiles */
   const segmentLength = Math.floor(2.4);
-  const faultNoiseScaling = 1700000 / metersPerCoord;
+  const faultNoiseScaling = scale;
 
   faults.forEach((fault) => {
     // Calculate edge unit-slope and its perpendicular
@@ -21,10 +27,10 @@ export function perturbPlateEdges(faults: Fault[], metersPerCoord: number): void
 
     // These settings control how the faults look
     const noise = new SimplexNoise('test', {
-      frequency: 4.8 * 10 ** -8 * metersPerCoord,
-      octaves: 10,
-      lacunarity: 1.85,
-      gain: 0.53,
+      frequency,
+      octaves,
+      lacunarity,
+      gain,
     });
 
     // Calculate perturbations by

--- a/src/1-game-code/World/TerrainGen/tectonicRasterization/constants.ts
+++ b/src/1-game-code/World/TerrainGen/tectonicRasterization/constants.ts
@@ -1,3 +1,0 @@
-export const defaultHilliness = 1;
-export const mountainHilliness = 5000;
-export const hillHilliness = 3000;

--- a/src/1-game-code/World/TerrainGen/tectonicRasterization/shapeCoasts.ts
+++ b/src/1-game-code/World/TerrainGen/tectonicRasterization/shapeCoasts.ts
@@ -6,7 +6,12 @@ import { Fault } from '../Fault';
 import { floodfillFromFault } from './floodfillFromFault';
 import { TecPlate } from '../TecPlate';
 
-export function shapeCoasts(elevLayer: DataLayer, faults: Fault[], tecPlates: TecPlate[]): void {
+export function shapeCoasts(
+  elevLayer: DataLayer,
+  faults: Fault[],
+  tecPlates: TecPlate[],
+  coastSlope: number,
+): void {
   const { height, width } = elevLayer;
   const coastDistanceMap: number[] = initializeArrayWithValue(height * width, 1000000);
   const processed: boolean[] = initializeArrayWithValue(height * width, false);
@@ -38,11 +43,11 @@ export function shapeCoasts(elevLayer: DataLayer, faults: Fault[], tecPlates: Te
   /** Apply an elevation function based on distance from coast
    *
    * At t = 0, elevation = coastal shelf at -150m.
-   * Slope up at 50m / 100,000m until reach continent elevation.
+   * Slope up at 25m / 100,000m until reach continent elevation.
    *
    * Floodfill from continent centers.
    */
-  const slope = 50 / 100000;
+
   tecPlates.forEach((tecPlate) => {
     const { center, isOceanic } = tecPlate;
     if (isOceanic) return;
@@ -55,7 +60,7 @@ export function shapeCoasts(elevLayer: DataLayer, faults: Fault[], tecPlates: Te
       const cur = floodQueue.pop();
       const [x, y] = cur;
       const t = coastDistanceMap[x + y * width];
-      const newElev = elevLayer.metersPerCoord * slope * t - 150;
+      const newElev = elevLayer.metersPerCoord * coastSlope * t - 150;
       const oldElev = elevLayer.at(x, y);
 
       // Why does this work? Don't we initialize elevations to -1,000,000?

--- a/src/3-frontend-api/worldMap/getWorldMap.ts
+++ b/src/3-frontend-api/worldMap/getWorldMap.ts
@@ -3,13 +3,16 @@ import { DataLayer } from '1-game-code/World';
 import { WorldMapCmpt } from '1-game-code/World/WorldMapCmpt';
 import { Selector } from '4-react-ecsal';
 
-export const getWorldMap: Selector<WorldMapCmpt> = (eMgr: EntityManager) => {
-  const worldMapCmpt = eMgr.getUniqueCmpt(WorldMapCmpt);
+export const getWorldMap: Selector<WorldMapCmpt | undefined> = (eMgr: EntityManager) => {
+  const worldMapCmpt = eMgr.tryGetUniqueCmpt(WorldMapCmpt);
   return worldMapCmpt;
 };
 
-export const getWorldMapLayer = (layer: string): Selector<DataLayer> => (eMgr: EntityManager) => {
+export const getWorldMapLayer = (layer: string): Selector<DataLayer | undefined> => (
+  eMgr: EntityManager,
+) => {
   const worldMapCmpt = getWorldMap(eMgr);
+  if (!worldMapCmpt) return undefined;
   const dataLayer = worldMapCmpt.data.dataLayers[layer];
   return dataLayer;
 };

--- a/src/5-react-components/useElementSize.ts
+++ b/src/5-react-components/useElementSize.ts
@@ -1,0 +1,25 @@
+import React, { useLayoutEffect, useState } from 'react';
+
+export function useElementSize(ref: React.RefObject<HTMLElement>): [number, number] {
+  const [size, setSize] = useState<[number, number]>([0, 0]);
+  useLayoutEffect(() => {
+    const el = ref.current;
+    function updateSize() {
+      if (el) {
+        const { clientWidth, clientHeight } = el;
+        setSize([clientWidth, clientHeight]);
+      }
+    }
+
+    if (el) {
+      el.addEventListener('resize', updateSize);
+      updateSize();
+    }
+    return () => {
+      if (el) {
+        el.removeEventListener('resize', updateSize);
+      }
+    };
+  }, [ref]);
+  return size;
+}

--- a/src/5-react-components/useZoomOnScroll.test.tsx
+++ b/src/5-react-components/useZoomOnScroll.test.tsx
@@ -19,18 +19,18 @@ describe('useZoomOnScroll', () => {
     const { container, getByTestId } = render(<TestCanvas />);
     expect(container).toHaveTextContent('1.0');
 
-    fireEvent.wheel(getByTestId('canvas'), { deltaY: 10000 });
+    fireEvent.wheel(getByTestId('canvas'), { deltaY: -10000 });
     await waitFor(() => screen.getByText('2.0'));
     expect(container).toHaveTextContent('2.0');
   });
 
   it('does not zoom past default min and max', async () => {
     const { container, getByTestId } = render(<TestCanvas />);
-    fireEvent.wheel(getByTestId('canvas'), { deltaY: 100000 });
+    fireEvent.wheel(getByTestId('canvas'), { deltaY: -100000 });
     await waitFor(() => screen.getByText('2.0'));
     expect(container).toHaveTextContent('2.0');
 
-    fireEvent.wheel(getByTestId('canvas'), { deltaY: -100000 });
+    fireEvent.wheel(getByTestId('canvas'), { deltaY: 100000 });
     await waitFor(() => screen.getByText('1.0'));
     expect(container).toHaveTextContent('1.0');
   });

--- a/src/5-react-components/useZoomOnScroll.ts
+++ b/src/5-react-components/useZoomOnScroll.ts
@@ -13,7 +13,7 @@ export default function useZoomOnScroll(
       e.preventDefault();
       const { deltaY } = e;
       setScale(([, sc]) => {
-        return [sc, Math.min(max, Math.max(min, sc * (1 + deltaY * 0.0001)))];
+        return [sc, Math.min(max, Math.max(min, sc * (1 - deltaY * 0.0001)))];
       });
     },
     [max, min],

--- a/src/6-ui-features/CharacterCreationScene/CharacterSummaryColumn.tsx
+++ b/src/6-ui-features/CharacterCreationScene/CharacterSummaryColumn.tsx
@@ -3,7 +3,8 @@ import styled from '@emotion/styled';
 import { useDispatch } from '4-react-ecsal';
 import { useDispatch as useReduxDispatch } from 'react-redux';
 import { useIsTest } from '6-ui-features/TestContext';
-import { createWorldMap } from '1-game-code/World/TerrainGen/TerrainGenSys';
+import { createWorld } from '6-ui-features/WorldGenScene/Sidebar/createWorld';
+import { WorldGenTabs, WorldGenTabsTest } from '6-ui-features/WorldGenScene/Sidebar/constants';
 import CharacterSummary from './components/CharacterSummary';
 import { randomizeAll, finishCharacterCreation } from './characterCreationSlice';
 import { changedScene, Scene } from '../sceneManager/sceneMetaSlice';
@@ -19,9 +20,9 @@ const CharacterSummaryColumn = (): JSX.Element => {
 
   const handleFinish = async () => {
     if (isTest) {
-      await dispatch(createWorldMap({ numPlates: 6, size: { x: 200, y: 100 } }));
+      await dispatch(createWorld(WorldGenTabs));
     } else {
-      await dispatch(createWorldMap({ numPlates: 7, size: { x: 800, y: 400 } }));
+      await dispatch(createWorld(WorldGenTabsTest));
     }
     reduxDispatch(finishCharacterCreation());
     reduxDispatch(changedScene(Scene.Town));

--- a/src/6-ui-features/CharacterCreationScene/CharacterSummaryColumn.tsx
+++ b/src/6-ui-features/CharacterCreationScene/CharacterSummaryColumn.tsx
@@ -20,9 +20,9 @@ const CharacterSummaryColumn = (): JSX.Element => {
 
   const handleFinish = async () => {
     if (isTest) {
-      await dispatch(createWorld(WorldGenTabs));
-    } else {
       await dispatch(createWorld(WorldGenTabsTest));
+    } else {
+      await dispatch(createWorld(WorldGenTabs));
     }
     reduxDispatch(finishCharacterCreation());
     reduxDispatch(changedScene(Scene.Town));

--- a/src/6-ui-features/WorldGenScene/Map.tsx
+++ b/src/6-ui-features/WorldGenScene/Map.tsx
@@ -1,0 +1,43 @@
+import React, { useRef } from 'react';
+import styled from '@emotion/styled';
+import { useDataLayerRenderer } from '6-ui-features/WorldMap/useDataLayerRenderer';
+import { colorElevation } from '6-ui-features/WorldMap/coloringFuncs';
+import { WorldMap } from '1-game-code/World/WorldMap';
+import { getWorldMapLayer } from '3-frontend-api/worldMap';
+import { useSelector } from '4-react-ecsal';
+import useZoomOnScroll from '5-react-components/useZoomOnScroll';
+import { useElementSize } from '5-react-components/useElementSize';
+
+export function Map(): JSX.Element {
+  const elevations = useSelector(getWorldMapLayer(WorldMap.Layer.Elevation));
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const scale = useZoomOnScroll(canvasRef);
+
+  const [width, height] = useElementSize(containerRef);
+
+  useDataLayerRenderer(canvasRef, colorElevation, elevations, scale);
+
+  return (
+    <Container>
+      {!elevations && 'No map generated yet.'}
+      <FullDiv ref={containerRef}>
+        <canvas style={{ position: 'absolute' }} ref={canvasRef} height={height} width={width} />
+      </FullDiv>
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  grid-area: map;
+
+  padding: 1em 2em;
+  height: 100%;
+  width: 100%;
+  box-sizing: border-box;
+`;
+
+const FullDiv = styled.div`
+  height: 100%;
+  width: 100%;
+`;

--- a/src/6-ui-features/WorldGenScene/Sidebar/ButtonRow.tsx
+++ b/src/6-ui-features/WorldGenScene/Sidebar/ButtonRow.tsx
@@ -2,10 +2,14 @@ import React from 'react';
 import styled from '@emotion/styled';
 import { PrimaryButton } from '6-ui-features/DesignSystem/buttons/PrimaryButton';
 
-export function ButtonRow(): JSX.Element {
+type ButtonRowProps = {
+  onGo: () => void;
+};
+
+export function ButtonRow({ onGo }: ButtonRowProps): JSX.Element {
   return (
     <LastRow>
-      <PrimaryButton>Go!</PrimaryButton>
+      <PrimaryButton onClick={onGo}>Go!</PrimaryButton>
     </LastRow>
   );
 }

--- a/src/6-ui-features/WorldGenScene/Sidebar/SliderOptions.tsx
+++ b/src/6-ui-features/WorldGenScene/Sidebar/SliderOptions.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 export type SliderOptionProps = {
   name: string;
+  key: string;
   description: string;
   value: number;
   min: number;
@@ -49,9 +50,9 @@ export function SliderOptions({ options, onChange }: SliderOptionsProps): JSX.El
         <col span={1} style={{ width: '5em' }} />
       </colgroup>
       <tbody>
-        {options.map(({ name, description, value, min, max, step }) => (
+        {options.map(({ name, key, description, value, min, max, step }) => (
           <SliderOption
-            key={name}
+            key={key}
             name={name}
             description={description}
             value={value}

--- a/src/6-ui-features/WorldGenScene/Sidebar/TabContent.tsx
+++ b/src/6-ui-features/WorldGenScene/Sidebar/TabContent.tsx
@@ -6,9 +6,10 @@ import { ButtonRow } from './ButtonRow';
 export type TabContentProps = {
   content: { heading: string; options: SliderOptionsProps['options'] }[];
   onChange: (heading: string) => SliderOptionsProps['onChange'];
+  onGo: () => void;
 };
 
-export function TabContent({ content, onChange }: TabContentProps): JSX.Element {
+export function TabContent({ content, onChange, onGo }: TabContentProps): JSX.Element {
   return (
     <>
       {content.map(({ heading, options }) => (
@@ -17,7 +18,7 @@ export function TabContent({ content, onChange }: TabContentProps): JSX.Element 
           <SliderOptions options={options} onChange={onChange(heading)} />
         </>
       ))}
-      <ButtonRow />
+      <ButtonRow onGo={onGo} />
     </>
   );
 }

--- a/src/6-ui-features/WorldGenScene/Sidebar/TabContent.tsx
+++ b/src/6-ui-features/WorldGenScene/Sidebar/TabContent.tsx
@@ -13,10 +13,10 @@ export function TabContent({ content, onChange, onGo }: TabContentProps): JSX.El
   return (
     <>
       {content.map(({ heading, options }) => (
-        <>
+        <React.Fragment key={heading}>
           <SettingsHeading>{heading}</SettingsHeading>
           <SliderOptions options={options} onChange={onChange(heading)} />
-        </>
+        </React.Fragment>
       ))}
       <ButtonRow onGo={onGo} />
     </>

--- a/src/6-ui-features/WorldGenScene/Sidebar/constants/createNoiseSettings.ts
+++ b/src/6-ui-features/WorldGenScene/Sidebar/constants/createNoiseSettings.ts
@@ -1,5 +1,6 @@
 import { SliderOptionsProps } from '../SliderOptions';
 
+/** Generates props for an array of SliderOption components for a noise generator */
 export function createNoiseSettings(
   keyPrefix: string,
   args: {

--- a/src/6-ui-features/WorldGenScene/Sidebar/constants/createNoiseSettings.ts
+++ b/src/6-ui-features/WorldGenScene/Sidebar/constants/createNoiseSettings.ts
@@ -1,15 +1,19 @@
 import { SliderOptionsProps } from '../SliderOptions';
 
-export function createNoiseSettings(args: {
-  scale: number;
-  frequency: number;
-  octaves: number;
-  lacunarity: number;
-  gain: number;
-}): SliderOptionsProps['options'] {
+export function createNoiseSettings(
+  keyPrefix: string,
+  args: {
+    scale: number;
+    frequency: number;
+    octaves: number;
+    lacunarity: number;
+    gain: number;
+  },
+): SliderOptionsProps['options'] {
   const { scale, frequency, octaves, lacunarity, gain } = args;
   const scaleSettings = {
     name: 'Scale',
+    key: `${keyPrefix}Scale`,
     description: 'Altitude of the noise: [-scale, scale)',
     value: scale,
     min: scale / 10,
@@ -18,6 +22,7 @@ export function createNoiseSettings(args: {
   };
   const freqSettings = {
     name: 'Frequency',
+    key: `${keyPrefix}Frequency`,
     description: 'Frequency of the noise',
     value: frequency,
     min: frequency / 10,
@@ -26,6 +31,7 @@ export function createNoiseSettings(args: {
   };
   const octaveSettings = {
     name: 'Octaves',
+    key: `${keyPrefix}Octaves`,
     description: 'More octaves means the noise is computed at higher resolution.',
     value: octaves,
     min: 1,
@@ -34,6 +40,7 @@ export function createNoiseSettings(args: {
   };
   const lacunaritySettings = {
     name: 'Lacunarity',
+    key: `${keyPrefix}Lacunarity`,
     description: 'How much the frequency increases with each octave. Usually around 2.',
     value: lacunarity,
     min: 1.5,
@@ -42,6 +49,7 @@ export function createNoiseSettings(args: {
   };
   const gainSettings = {
     name: 'Gain',
+    key: `${keyPrefix}Gain`,
     description: 'How much the scale is decreased with each octave. Usually around 0.5.',
     value: gain,
     min: 0.3,

--- a/src/6-ui-features/WorldGenScene/Sidebar/constants/index.ts
+++ b/src/6-ui-features/WorldGenScene/Sidebar/constants/index.ts
@@ -1,4 +1,5 @@
-import { terrainGenControls } from './terrainGenControls';
+import produce from 'immer';
+import { terrainGenControls, terrainGenControlsTest } from './terrainGenControls';
 
 const blank = [{ heading: 'No configuration options.', options: [] }];
 
@@ -8,3 +9,7 @@ export const WorldGenTabs = [
   { text: 'Water', key: 'water', content: blank },
   { text: 'Civilizations', key: 'civilizations', content: blank },
 ] as const;
+
+export const WorldGenTabsTest = produce(WorldGenTabs, (draft) => {
+  draft[0].content = terrainGenControlsTest;
+});

--- a/src/6-ui-features/WorldGenScene/Sidebar/constants/terrainGenControls.ts
+++ b/src/6-ui-features/WorldGenScene/Sidebar/constants/terrainGenControls.ts
@@ -1,3 +1,4 @@
+import produce from 'immer';
 import { createNoiseSettings } from './createNoiseSettings';
 import { TabContentProps } from '../TabContent';
 
@@ -111,3 +112,20 @@ export const terrainGenControls: TabContentProps['content'] = [
     }),
   },
 ];
+
+/** Smaller map for tests */
+export const terrainGenControlsTest = produce(terrainGenControls, (draft) => {
+  const generalOptions = draft[0].options;
+  const widthOption = generalOptions.find(({ key }) => key === 'width');
+  if (widthOption) {
+    widthOption.value = 200;
+  }
+  const heightOption = generalOptions.find(({ key }) => key === 'height');
+  if (heightOption) {
+    heightOption.value = 100;
+  }
+  const numPlates = generalOptions.find(({ key }) => key === 'numPlates');
+  if (numPlates) {
+    numPlates.value = 5;
+  }
+});

--- a/src/6-ui-features/WorldGenScene/Sidebar/constants/terrainGenControls.ts
+++ b/src/6-ui-features/WorldGenScene/Sidebar/constants/terrainGenControls.ts
@@ -7,6 +7,7 @@ export const terrainGenControls: TabContentProps['content'] = [
     options: [
       {
         name: 'Width (tiles)',
+        key: 'width',
         description: 'Map width in tiles. 1 tile = 4092 m.',
         value: 800,
         min: 100,
@@ -15,6 +16,7 @@ export const terrainGenControls: TabContentProps['content'] = [
       },
       {
         name: 'Height (tiles)',
+        key: 'height',
         description: 'Map height in tiles. 1 tile = 4092 m.',
         value: 400,
         min: 50,
@@ -23,6 +25,7 @@ export const terrainGenControls: TabContentProps['content'] = [
       },
       {
         name: 'Tectonic Plates',
+        key: 'numPlates',
         description: 'Number of tectonic plates.',
         value: 7,
         min: 5,
@@ -31,6 +34,7 @@ export const terrainGenControls: TabContentProps['content'] = [
       },
       {
         name: 'Percent Ocean',
+        key: 'oceanFrac',
         description:
           'Percent of plates that are oceanic. When set to 0, all plates will be continental.',
         value: 65,
@@ -43,7 +47,7 @@ export const terrainGenControls: TabContentProps['content'] = [
   // Noise settings for fault perturbation
   {
     heading: 'Fault Shape',
-    options: createNoiseSettings({
+    options: createNoiseSettings('faultPerturbation', {
       scale: 425,
       frequency: 2 * 10 ** -4,
       octaves: 10,
@@ -56,6 +60,7 @@ export const terrainGenControls: TabContentProps['content'] = [
     options: [
       {
         name: 'Coast Slope',
+        key: 'coastSlope',
         description:
           'Average slope of coastal areas. A low value means large coastal areas, beaches, and continental shelves.',
         value: 50 / 100000,
@@ -65,6 +70,7 @@ export const terrainGenControls: TabContentProps['content'] = [
       },
       {
         name: 'Mountain Slope',
+        key: 'ridgeSlope',
         description:
           'Average slope of mountains. A low value leads to large mountainous regions, but the generator may have difficulty fitting them in.',
         value: 0.01,
@@ -74,6 +80,7 @@ export const terrainGenControls: TabContentProps['content'] = [
       },
       {
         name: 'Rift Slope',
+        key: 'riftSlope',
         description:
           "Average slope of rifts. You won't interact with this much since most rifts are underwater.",
         value: 0.01,
@@ -85,7 +92,7 @@ export const terrainGenControls: TabContentProps['content'] = [
   },
   {
     heading: 'Low Frequency Noise',
-    options: createNoiseSettings({
+    options: createNoiseSettings('lowFreqNoise', {
       scale: 2000,
       frequency: 0.003,
       octaves: 8,
@@ -95,7 +102,7 @@ export const terrainGenControls: TabContentProps['content'] = [
   },
   {
     heading: 'Ridge Noise',
-    options: createNoiseSettings({
+    options: createNoiseSettings('ridgeNoise', {
       scale: 5000, // Corresponds to maximum `hilliness`
       frequency: 0.012,
       octaves: 10,

--- a/src/6-ui-features/WorldGenScene/Sidebar/createWorld.ts
+++ b/src/6-ui-features/WorldGenScene/Sidebar/createWorld.ts
@@ -13,6 +13,7 @@ export const createWorld = (settings: typeof WorldGenTabs): Thunk => async (disp
   return dispatch(createWorldMap(terrainGenParams));
 };
 
+/** Parses the UI settings data format into the payload expected by the backend */
 function parseTerrainGenParams(content: typeof terrainGenControls): TerrainGenParams {
   const generalOptions = parseContentSectionIntoDict(content, 'General');
   const { width, height, numPlates, oceanFrac: oceanPercent } = generalOptions;

--- a/src/6-ui-features/WorldGenScene/Sidebar/createWorld.ts
+++ b/src/6-ui-features/WorldGenScene/Sidebar/createWorld.ts
@@ -1,0 +1,79 @@
+import { Thunk } from '0-engine/ECS/Thunk';
+import { NoiseParams } from '1-game-code/Noise';
+import { createWorldMap, TerrainGenParams } from '1-game-code/World/TerrainGen/TerrainGenSys';
+import { WorldGenTabs } from './constants';
+import { terrainGenControls } from './constants/terrainGenControls';
+import { TabContentProps } from './TabContent';
+
+/** Single function to create a new world. Covers entirety of world gen. */
+export const createWorld = (settings: typeof WorldGenTabs): Thunk => async (dispatch) => {
+  const [terrainSettings] = settings;
+  const { content } = terrainSettings;
+  const terrainGenParams = parseTerrainGenParams(content);
+  return dispatch(createWorldMap(terrainGenParams));
+};
+
+function parseTerrainGenParams(content: typeof terrainGenControls): TerrainGenParams {
+  const generalOptions = parseContentSectionIntoDict(content, 'General');
+  const { width, height, numPlates, oceanFrac: oceanPercent } = generalOptions;
+  const oceanFrac = oceanPercent / 100;
+  if (!width || !height || !numPlates || !oceanFrac)
+    throw new Error('Something went wrong gathering the world gen settings.');
+
+  const faultFeatureOptions = parseContentSectionIntoDict(content, 'Fault Features');
+  const { coastSlope, ridgeSlope, riftSlope } = faultFeatureOptions;
+  if (!coastSlope || !ridgeSlope || !riftSlope)
+    throw new Error('Something went wrong gathering world gen settings.');
+
+  const faultPerturbationNoise = parseNoiseSection(content, 'Fault Shape');
+  const lowFreqNoise = parseNoiseSection(content, 'Low Frequency Noise');
+  const ridgeNoise = parseNoiseSection(content, 'Ridge Noise');
+
+  const terrainGenParams: TerrainGenParams = {
+    width,
+    height,
+    numPlates,
+    oceanFrac,
+    coastSlope,
+    ridgeSlope,
+    riftSlope,
+    faultPerturbationNoise,
+    lowFreqNoise,
+    ridgeNoise,
+  };
+  return terrainGenParams;
+}
+
+function parseContentSectionIntoDict(
+  content: TabContentProps['content'],
+  heading: string,
+): { [key: string]: any } {
+  const dictionary = content
+    .find(({ heading: h }) => heading === h)
+    ?.options.reduce((dict, option) => {
+      dict[option.key] = option.value;
+      return dict;
+    }, {} as { [key: string]: any });
+  if (!dictionary) throw new Error('Something went wrong parsing the world gen settings.');
+  return dictionary;
+}
+
+function parseNoiseSection(content: TabContentProps['content'], heading: string): NoiseParams {
+  const dict = parseContentSectionIntoDict(content, heading);
+  const scaleKeyName = Object.keys(dict).find((key) => key.slice(-5) === 'Scale');
+  if (!scaleKeyName)
+    throw new Error('Noise param section was missing `scale` key. Was the wrong section passed?');
+  const prefix = scaleKeyName.slice(0, -5);
+  const freqKeyName = `${prefix}Frequency`;
+  const octavesKeyName = `${prefix}Octaves`;
+  const lacunarityKeyName = `${prefix}Lacunarity`;
+  const gainKeyName = `${prefix}Gain`;
+  const {
+    [scaleKeyName]: scale,
+    [freqKeyName]: frequency,
+    [octavesKeyName]: octaves,
+    [lacunarityKeyName]: lacunarity,
+    [gainKeyName]: gain,
+  } = dict;
+  return { scale, frequency, octaves, lacunarity, gain };
+}

--- a/src/6-ui-features/WorldGenScene/Sidebar/index.tsx
+++ b/src/6-ui-features/WorldGenScene/Sidebar/index.tsx
@@ -2,11 +2,14 @@ import React, { ChangeEvent, useState } from 'react';
 import styled from '@emotion/styled';
 import { getColor } from '6-ui-features/Theme';
 import produce from 'immer';
+import { useDispatch } from '4-react-ecsal';
 import { Tabs } from './Tabs';
 import { WorldGenTabs } from './constants';
 import { TabContent } from './TabContent';
+import { createWorld } from './createWorld';
 
 export function Sidebar(): JSX.Element {
+  const dispatch = useDispatch();
   const [selectedTab, setSelectedTab] = useState(Object.values(WorldGenTabs)[0].key);
   const [contentState, setContentState] = useState(WorldGenTabs);
 
@@ -34,12 +37,16 @@ export function Sidebar(): JSX.Element {
     setContentState(nextState);
   };
 
+  const generateWorld = () => {
+    void dispatch(createWorld(contentState));
+  };
+
   return (
     <Container>
       <Tabs selected={selectedTab} onChange={setSelectedTab} />
       <Content>
         {content ? (
-          <TabContent content={content} onChange={onChange} />
+          <TabContent content={content} onChange={onChange} onGo={generateWorld} />
         ) : (
           'There was an error finding the settings.'
         )}

--- a/src/6-ui-features/WorldGenScene/Sidebar/index.tsx
+++ b/src/6-ui-features/WorldGenScene/Sidebar/index.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import { getColor } from '6-ui-features/Theme';
 import produce from 'immer';
 import { useDispatch } from '4-react-ecsal';
+import { GameManager } from '0-engine/GameManager';
 import { Tabs } from './Tabs';
 import { WorldGenTabs } from './constants';
 import { TabContent } from './TabContent';
@@ -37,8 +38,9 @@ export function Sidebar(): JSX.Element {
     setContentState(nextState);
   };
 
-  const generateWorld = () => {
-    void dispatch(createWorld(contentState));
+  const generateWorld = async () => {
+    await GameManager.instance.eMgr.restart();
+    await dispatch(createWorld(contentState));
   };
 
   return (

--- a/src/6-ui-features/WorldGenScene/index.tsx
+++ b/src/6-ui-features/WorldGenScene/index.tsx
@@ -2,6 +2,7 @@ import { getColor } from '6-ui-features/Theme';
 import styled from '@emotion/styled';
 import React from 'react';
 import { Sidebar } from './Sidebar';
+import { Map } from './Map';
 
 export default function WorldGenScene(): JSX.Element {
   return (
@@ -10,7 +11,7 @@ export default function WorldGenScene(): JSX.Element {
         <h1>World Generation</h1>
       </Header>
       <Sidebar />
-      <Map>Map</Map>
+      <Map />
     </Page>
   );
 }
@@ -33,12 +34,6 @@ const Page = styled.div`
 
 const Header = styled.div`
   grid-area: header;
-
-  padding: 1em 2em;
-`;
-
-const Map = styled.div`
-  grid-area: map;
 
   padding: 1em 2em;
 `;

--- a/src/6-ui-features/WorldMap/coloringFuncs.ts
+++ b/src/6-ui-features/WorldMap/coloringFuncs.ts
@@ -1,0 +1,38 @@
+import { Color, colorInterp } from './Color';
+
+const colors: Color[] = [
+  [0, 5, 70, 255],
+  [0, 55, 120, 255],
+  [0, 119, 190, 255],
+  [137, 207, 245, 255],
+  [200, 198, 164, 255],
+  [155, 177, 125, 255],
+  // [220, 230, 220, 220],
+  [119, 119, 119, 255],
+  [238, 238, 238, 238],
+];
+
+export function colorElevation(elev: number): Color {
+  if (elev < -7000) {
+    return colors[0];
+  }
+  if (elev < -5000) {
+    return colorInterp(elev, -7000, -5000, colors[0], colors[1]);
+  }
+  if (elev < -2000) {
+    return colorInterp(elev, -5000, -2000, colors[1], colors[2]);
+  }
+  if (elev < 0) {
+    return colorInterp(elev, -2000, 0, colors[2], colors[3]);
+  }
+  if (elev < 2000) {
+    return colorInterp(elev, 0, 2000, colors[4], colors[5]);
+  }
+  if (elev < 4000) {
+    return colorInterp(elev, 2000, 4000, colors[5], colors[6]);
+  }
+  if (elev < 8000) {
+    return colorInterp(elev, 4000, 8000, colors[6], colors[7]);
+  }
+  return colors[7];
+}

--- a/src/6-ui-features/WorldMap/useDataLayerRenderer.ts
+++ b/src/6-ui-features/WorldMap/useDataLayerRenderer.ts
@@ -1,0 +1,62 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { DataLayer } from '1-game-code/World';
+import { Color } from './Color';
+import PixelMap from './PixelMap';
+
+/** Renders a DataLayer onto a canvas via PixelMap and ImageBitmap */
+export function useDataLayerRenderer(
+  canvasRef: React.RefObject<HTMLCanvasElement>,
+  colorFunc: (num: number) => Color,
+  dataLayer?: DataLayer,
+
+  /** This argument should come from `useZoomOnScroll` */
+  scale = 1,
+  useShearedElev = false,
+): void {
+  const pixelMap = useRef<PixelMap | undefined>();
+  const [imageBitmap, setImageBitmap] = useState(null as ImageBitmap | null);
+
+  const drawImage = useCallback(
+    (renderer: ImageBitmap) => {
+      const canvas = canvasRef.current;
+      if (canvas) {
+        const cW = canvas.width;
+        const cH = canvas.height;
+        const ctx = canvas.getContext('2d');
+        ctx?.drawImage(renderer, 0, 0, cW, cH);
+      }
+    },
+    [canvasRef],
+  );
+
+  // If the dataLayer size changes or colorFunc changes, we need to re-instantiate the pixelmap
+  useEffect(() => {
+    if (!dataLayer) return; // Nothing to render
+    if (
+      !pixelMap.current ||
+      pixelMap.current.height !== dataLayer.height ||
+      pixelMap.current.width !== dataLayer.width ||
+      pixelMap.current.coloringFunc !== colorFunc
+    ) {
+      pixelMap.current = new PixelMap(dataLayer, colorFunc);
+    }
+  }, [dataLayer, colorFunc]);
+
+  // Update the pixel map and bitmap
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !pixelMap.current || !dataLayer) return;
+
+    pixelMap.current.updateFromDataLayer(dataLayer, useShearedElev);
+    const img = pixelMap.current.toImageData();
+
+    void createImageBitmap(img).then((bitmap) => setImageBitmap(bitmap));
+  }, [canvasRef, drawImage, dataLayer, useShearedElev]);
+
+  // Redraw the image bitmap whenever it changes or we zoom in/out
+  useEffect(() => {
+    if (imageBitmap) {
+      drawImage(imageBitmap);
+    }
+  }, [drawImage, imageBitmap, scale]);
+}


### PR DESCRIPTION
- I think in the future I'll want to convert some of the terrain gen
  files, especially propagage from faults, to use object params for
  functions. The long lists of numbers have a high chance of
  accidentally swapping arguments.
- Still need to display the map in order to check whether it's being
  generated correctly.

Fixes: nmkataoka/adv-life#330

## Checklist

- [ ] PR is of reasonable size
