### PR TITLE
Make oceanFrac a guarantee

### DIFF
--- a/src/1-game-code/World/TerrainGen/tectonicGeneration/createPlatesAndFaults.ts
+++ b/src/1-game-code/World/TerrainGen/tectonicGeneration/createPlatesAndFaults.ts
@@ -1,4 +1,5 @@
 import { Random } from '1-game-code/prng';
+import { shuffle } from '8-helpers/ArrayExtensions';
 import { Vector2 } from '8-helpers/math';
 import { createFaultFromEdge, Fault } from '../Fault';
 import { TecPlate } from '../TecPlate';
@@ -14,10 +15,12 @@ export function createPlatesAndFaults(
 ): { tecPlates: TecPlate[]; faults: Fault[] } {
   const { points, edges, xSize, isCylindrical } = voronoi;
 
-  const tecPlates: TecPlate[] = points.map((point) => ({
-    ...randomizePlateProperties(oceanFrac, rng),
+  const isOceanicArr = getRandomizedIsOceanic(points.length, oceanFrac, rng);
+  const tecPlates: TecPlate[] = points.map((point, idx) => ({
+    ...randomizePlateProperties(rng),
+    isOceanic: isOceanicArr[idx],
     center: point,
-    faults: [], // Placeholder
+    faults: [], // Placeholder, fault assignment is complicated and done separately
   }));
 
   const faults: Fault[] = [];
@@ -43,13 +46,25 @@ export function createPlatesAndFaults(
   return { faults, tecPlates };
 }
 
-function randomizePlateProperties(
-  oceanFrac: number,
-  rng: Random,
-): Omit<TecPlate, 'center' | 'faults'> {
+/**
+ * In order to make oceanFrac a guarantee instead of just a probability,
+ * generate all the isOceanic properties at once.
+ */
+function getRandomizedIsOceanic(numPlates: number, oceanFrac: number, rng: Random): boolean[] {
+  const arr: boolean[] = [];
+  for (let i = 0; i < numPlates * oceanFrac; ++i) {
+    arr.push(true);
+  }
+  for (let i = Math.floor(numPlates * oceanFrac) + 1; i < numPlates; ++i) {
+    arr.push(false);
+  }
+  shuffle(arr, rng);
+  return arr;
+}
+
+function randomizePlateProperties(rng: Random): Omit<TecPlate, 'center' | 'faults' | 'isOceanic'> {
   return {
     age: rng.random(),
-    isOceanic: rng.random() < oceanFrac,
     velocity: new Vector2(rng.random() * 10, 0).rotate(rng.random() * 2 * PI),
   };
 }


### PR DESCRIPTION
Fixes: kingstreetlabs/KingStreetLabs#324

oceanFrac was previously just a probability. It was possible to use
oceanFrac 0.1 and get all 90% land. Changed so that the number of
ocean plates is guaranteed to match oceanFrac.

Fixes: nmkataoka/adv-life#

## Checklist

- [x] PR is of reasonable size
