### PR TITLE
Remove unnecessary 'react' imports

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -47,9 +47,11 @@
     "react/jsx-filename-extension": 0,
     "react/jsx-indent": 0, // disabled because we have prettier
     "react/jsx-one-expression-per-line": 0, // disabled because we have prettier
+    "react/jsx-uses-react": 0, // no longer necessary with React 17 JSX transform
     "react/no-array-index-key": "warn",
     "react/no-unused-prop-types": "warn",
     "react/prop-types": 0,
+    "react/react-in-jsx-scope": 0, // no longer necessary with React 17 JSX transform
     "react/require-default-props": 0,
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",

--- a/src/4-react-ecsal/components/Context.ts
+++ b/src/4-react-ecsal/components/Context.ts
@@ -1,6 +1,6 @@
 import { EntityManager } from '0-engine';
 import { Subscription } from '4-react-ecsal/utils/Subscription';
-import React from 'react';
+import { Context, createContext } from 'react';
 
 export type ContextValue = {
   store: EntityManager;
@@ -9,7 +9,7 @@ export type ContextValue = {
 
 // eslint-disable-next-line
 // @ts-ignore React.createContext default value has typescript issues
-const ReactEcsalContext: React.Context<ContextValue> = React.createContext(null);
+const ReactEcsalContext: Context<ContextValue> = createContext(null);
 
 if (process.env.NODE_ENV !== 'production') {
   ReactEcsalContext.displayName = 'ReactRedux';

--- a/src/4-react-ecsal/components/Provider.tsx
+++ b/src/4-react-ecsal/components/Provider.tsx
@@ -1,12 +1,12 @@
 import { EntityManager } from '0-engine';
 import { Subscription } from '4-react-ecsal/utils/Subscription';
-import React, { useEffect, useMemo } from 'react';
+import { Context as ReactContext, useEffect, useMemo, ReactNode } from 'react';
 import ReactEcsalContext, { ContextValue } from './Context';
 
 type ProviderProps = {
   store: EntityManager;
-  context?: React.Context<ContextValue>;
-  children: React.ReactNode;
+  context?: ReactContext<ContextValue>;
+  children: ReactNode;
 };
 
 const Provider = ({ store, context, children }: ProviderProps): JSX.Element => {

--- a/src/5-react-components/Image.tsx
+++ b/src/5-react-components/Image.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 type ImageProps = {
   alt: string;
   className?: string;

--- a/src/5-react-components/Modal/index.test.tsx
+++ b/src/5-react-components/Modal/index.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { stub } from 'sinon';
 import { render, fireEvent, screen, waitFor } from '8-helpers/test-utils';
 

--- a/src/5-react-components/Modal/index.tsx
+++ b/src/5-react-components/Modal/index.tsx
@@ -1,11 +1,11 @@
-import React, { useState, useMemo, useCallback, useEffect } from 'react';
+import { useState, useMemo, useCallback, useEffect, ReactNode } from 'react';
 import styled from '@emotion/styled';
 import { useSelector, useDispatch } from 'react-redux';
 import { RootState } from '7-app/types';
 import { usedModalZIndex } from './modalMetaSlice';
 
 type ModalProps = {
-  children?: React.ReactNode;
+  children?: ReactNode;
   isShowing?: boolean;
   onClose?: () => void;
 };

--- a/src/5-react-components/useElementSize.ts
+++ b/src/5-react-components/useElementSize.ts
@@ -1,6 +1,6 @@
-import React, { useLayoutEffect, useState } from 'react';
+import { useLayoutEffect, useState, RefObject } from 'react';
 
-export function useElementSize(ref: React.RefObject<HTMLElement>): [number, number] {
+export function useElementSize(ref: RefObject<HTMLElement>): [number, number] {
   const [size, setSize] = useState<[number, number]>([0, 0]);
   useLayoutEffect(() => {
     const el = ref.current;

--- a/src/5-react-components/useOnWheel.ts
+++ b/src/5-react-components/useOnWheel.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, RefObject } from 'react';
 
 /** Registers an active listener for the `wheel` event
  *
@@ -6,7 +6,7 @@ import { useEffect } from 'react';
  * Most logic handling requires onWheel to be registered as an active event listener.
  */
 export function useOnWheel(
-  ref: React.RefObject<HTMLCanvasElement | null>,
+  ref: RefObject<HTMLCanvasElement | null>,
   handler: (e: WheelEvent) => void,
 ): void {
   useEffect(() => {

--- a/src/6-ui-features/CharacterCreationScene/CharacterAttributeGroup/Freeform/FreeformInputWindow.tsx
+++ b/src/6-ui-features/CharacterCreationScene/CharacterAttributeGroup/Freeform/FreeformInputWindow.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { ChangeEvent } from 'react';
 import styled from '@emotion/styled';
 import { useDispatch } from 'react-redux';
 import Window from '../../components/Window';
@@ -18,7 +18,7 @@ type FreeformInputWindowProps = {
 const FreeformInputWindow = ({ header, options }: FreeformInputWindowProps): JSX.Element => {
   const dispatch = useDispatch();
 
-  const handleChange = (label: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChange = (label: string) => (e: ChangeEvent<HTMLInputElement>) => {
     dispatch(changedFreeformInputValue({ label, value: e.target.value }));
   };
 

--- a/src/6-ui-features/CharacterCreationScene/CharacterAttributeGroup/OneOf/SelectionWindow.tsx
+++ b/src/6-ui-features/CharacterCreationScene/CharacterAttributeGroup/OneOf/SelectionWindow.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import { useDispatch } from 'react-redux';
 import Window from '../../components/Window';

--- a/src/6-ui-features/CharacterCreationScene/CharacterAttributeGroup/PointAllocation/AttributeRow.tsx
+++ b/src/6-ui-features/CharacterCreationScene/CharacterAttributeGroup/PointAllocation/AttributeRow.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import { useDispatch } from 'react-redux';
 import {

--- a/src/6-ui-features/CharacterCreationScene/CharacterAttributeGroup/PointAllocation/AttributeWindow.tsx
+++ b/src/6-ui-features/CharacterCreationScene/CharacterAttributeGroup/PointAllocation/AttributeWindow.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import Window from '../../components/Window';
 import AttributeRow, { AttributeRowProps } from './AttributeRow';

--- a/src/6-ui-features/CharacterCreationScene/CharacterAttributeGroup/Ranges/SliderRow.tsx
+++ b/src/6-ui-features/CharacterCreationScene/CharacterAttributeGroup/Ranges/SliderRow.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { ChangeEvent } from 'react';
 import styled from '@emotion/styled';
 import { useDispatch } from 'react-redux';
 import { updateInfoWindow, changedSlider } from '../../characterCreationSlice';
@@ -28,7 +28,7 @@ export default function SliderRow({
     dispatch(updateInfoWindow({ infoWindowTitle: maxLabel, infoWindowText: info }));
   };
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     dispatch(changedSlider({ label: maxLabel, value: parseInt(e.target.value, 10) }));
   };
 

--- a/src/6-ui-features/CharacterCreationScene/CharacterAttributeGroup/Ranges/SliderWindow.tsx
+++ b/src/6-ui-features/CharacterCreationScene/CharacterAttributeGroup/Ranges/SliderWindow.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import Window from '../../components/Window';
 import SliderRow, { SliderRowProps } from './SliderRow';

--- a/src/6-ui-features/CharacterCreationScene/CharacterCreationNavBar.tsx
+++ b/src/6-ui-features/CharacterCreationScene/CharacterCreationNavBar.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import { useDispatch } from 'react-redux';
 import { changedScreen } from './characterCreationSlice';

--- a/src/6-ui-features/CharacterCreationScene/CharacterSummaryColumn.tsx
+++ b/src/6-ui-features/CharacterCreationScene/CharacterSummaryColumn.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import { useDispatch } from '4-react-ecsal';
 import { useDispatch as useReduxDispatch } from 'react-redux';

--- a/src/6-ui-features/CharacterCreationScene/components/CharacterSummary.tsx
+++ b/src/6-ui-features/CharacterCreationScene/components/CharacterSummary.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 
 const attributes = [

--- a/src/6-ui-features/CharacterCreationScene/components/InfoWindow.tsx
+++ b/src/6-ui-features/CharacterCreationScene/components/InfoWindow.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useSelector } from 'react-redux';
 import { RootState } from '7-app/types';
 import Window from './Window';

--- a/src/6-ui-features/CharacterCreationScene/components/NavigationButtons.tsx
+++ b/src/6-ui-features/CharacterCreationScene/components/NavigationButtons.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import { useDispatch } from 'react-redux';
 import { clickedNext, clickedPrevious } from '../characterCreationSlice';

--- a/src/6-ui-features/CharacterCreationScene/components/ScreenInfoToScreen.tsx
+++ b/src/6-ui-features/CharacterCreationScene/components/ScreenInfoToScreen.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import SelectionWindow from '../CharacterAttributeGroup/OneOf/SelectionWindow';
 import AttributeWindow from '../CharacterAttributeGroup/PointAllocation/AttributeWindow';
 import SliderWindow from '../CharacterAttributeGroup/Ranges/SliderWindow';

--- a/src/6-ui-features/CharacterCreationScene/components/Window.tsx
+++ b/src/6-ui-features/CharacterCreationScene/components/Window.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { ReactNode } from 'react';
 import styled from '@emotion/styled';
 import { useDispatch } from 'react-redux';
 import NavigationButtons from './NavigationButtons';
@@ -6,7 +6,7 @@ import Header from './Header';
 import { randomizeCurrentWindow } from '../characterCreationSlice';
 
 type WindowProps = {
-  children?: React.ReactNode;
+  children?: ReactNode;
   header: string;
   randomize?: boolean;
   showNavigation?: boolean;

--- a/src/6-ui-features/CharacterInfo/CharacterEquipment.tsx
+++ b/src/6-ui-features/CharacterInfo/CharacterEquipment.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import { useSelector } from '4-react-ecsal';
 import { EntityManager } from '0-engine';

--- a/src/6-ui-features/CharacterInfo/CharacterInventory.tsx
+++ b/src/6-ui-features/CharacterInfo/CharacterInventory.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import { InventorySlotInfo } from '3-frontend-api/inventory/InventoryInfo';
 import ItemStack from './ItemStack';

--- a/src/6-ui-features/CharacterInfo/InventoryScreen.tsx
+++ b/src/6-ui-features/CharacterInfo/InventoryScreen.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import { useSelector } from '4-react-ecsal';
 import { getPlayerInventory } from '3-frontend-api';

--- a/src/6-ui-features/CharacterInfo/ItemStack.tsx
+++ b/src/6-ui-features/CharacterInfo/ItemStack.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import { useSelector } from '4-react-ecsal';
 import { getItemClass } from '3-frontend-api/items/getItemClass';

--- a/src/6-ui-features/ColosseumScene/ActionBar/ActionButton.tsx
+++ b/src/6-ui-features/ColosseumScene/ActionBar/ActionButton.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 
 type ActionButtonProps = {

--- a/src/6-ui-features/ColosseumScene/ActionBar/index.tsx
+++ b/src/6-ui-features/ColosseumScene/ActionBar/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import ActionButton from './ActionButton';
 

--- a/src/6-ui-features/ColosseumScene/Unit/index.tsx
+++ b/src/6-ui-features/ColosseumScene/Unit/index.tsx
@@ -1,5 +1,5 @@
 import { MeshProps } from '9-three-helpers';
-import React, { useRef, useState } from 'react';
+import { MouseEvent, useRef, useState } from 'react';
 import { Mesh } from 'three';
 
 type UnitProps = MeshProps & {
@@ -15,7 +15,7 @@ export default function Unit(props: UnitProps): JSX.Element {
   const [hovered, setHover] = useState(false);
   const [active, setActive] = useState(false);
 
-  const handleClick = (e: React.MouseEvent) => {
+  const handleClick = (e: MouseEvent) => {
     e.stopPropagation();
     setActive(!active);
   };

--- a/src/6-ui-features/ColosseumScene/index.tsx
+++ b/src/6-ui-features/ColosseumScene/index.tsx
@@ -1,5 +1,4 @@
 import { RootState } from '7-app/types';
-import React from 'react';
 import styled from '@emotion/styled';
 import { useSelector as useReduxSelector } from 'react-redux';
 import { useSelector } from '4-react-ecsal';

--- a/src/6-ui-features/CombatLog/index.tsx
+++ b/src/6-ui-features/CombatLog/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import { useSelector } from '4-react-ecsal';
 import { getCombatLog } from '3-frontend-api/combatLog/getCombatLog';

--- a/src/6-ui-features/CombatScene/RecoveryBar.tsx
+++ b/src/6-ui-features/CombatScene/RecoveryBar.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import { useSelector } from 'react-redux';
 import { RootState } from '7-app/types';

--- a/src/6-ui-features/DesignSystem/BoxShadow.stories.tsx
+++ b/src/6-ui-features/DesignSystem/BoxShadow.stories.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Story, Meta } from '@storybook/react';
 
 type BoxShadowProps = {

--- a/src/6-ui-features/DesignSystem/buttons/PrimaryButton.tsx
+++ b/src/6-ui-features/DesignSystem/buttons/PrimaryButton.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import { getColor } from '6-ui-features/Theme';
 import { ButtonProps } from './ButtonProps';

--- a/src/6-ui-features/MainMenuScene/index.tsx
+++ b/src/6-ui-features/MainMenuScene/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import { changedScene, Scene } from '6-ui-features/sceneManager/sceneMetaSlice';
 import { useDispatch as useReduxDispatch } from 'react-redux';

--- a/src/6-ui-features/TopBar/index.tsx
+++ b/src/6-ui-features/TopBar/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import { useSelector } from 'react-redux';
 import { RootState } from '7-app/types';

--- a/src/6-ui-features/TownLocation/ItemStack.tsx
+++ b/src/6-ui-features/TownLocation/ItemStack.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import { useSelector } from '4-react-ecsal';
 import { getItemClass } from '3-frontend-api/items/getItemClass';

--- a/src/6-ui-features/TownLocation/ShopInventory.tsx
+++ b/src/6-ui-features/TownLocation/ShopInventory.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useDispatch, useSelector } from '4-react-ecsal';
 import styled from '@emotion/styled';
 import { getInventory, getPlayerInventory } from '3-frontend-api';

--- a/src/6-ui-features/TownScene/PartySummary.tsx
+++ b/src/6-ui-features/TownScene/PartySummary.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import PartyMember from './PartyMember';
 

--- a/src/6-ui-features/WorldGenScene/Sidebar/ButtonRow.tsx
+++ b/src/6-ui-features/WorldGenScene/Sidebar/ButtonRow.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import { PrimaryButton } from '6-ui-features/DesignSystem/buttons/PrimaryButton';
 

--- a/src/6-ui-features/WorldGenScene/Sidebar/SettingsHeading.tsx
+++ b/src/6-ui-features/WorldGenScene/Sidebar/SettingsHeading.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import { getColor } from '6-ui-features/Theme';
 

--- a/src/6-ui-features/WorldGenScene/Sidebar/TabContent.tsx
+++ b/src/6-ui-features/WorldGenScene/Sidebar/TabContent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { Fragment } from 'react';
 import { SettingsHeading } from './SettingsHeading';
 import { SliderOptions, SliderOptionsProps } from './SliderOptions';
 import { ButtonRow } from './ButtonRow';
@@ -13,10 +13,10 @@ export function TabContent({ content, onChange, onGo }: TabContentProps): JSX.El
   return (
     <>
       {content.map(({ heading, options }) => (
-        <React.Fragment key={heading}>
+        <Fragment key={heading}>
           <SettingsHeading>{heading}</SettingsHeading>
           <SliderOptions options={options} onChange={onChange(heading)} />
-        </React.Fragment>
+        </Fragment>
       ))}
       <ButtonRow onGo={onGo} />
     </>

--- a/src/6-ui-features/WorldGenScene/Sidebar/Tabs.tsx
+++ b/src/6-ui-features/WorldGenScene/Sidebar/Tabs.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import { getColor } from '6-ui-features/Theme';
 import { WorldGenTabs } from './constants';

--- a/src/6-ui-features/WorldMap/MapLocation.tsx
+++ b/src/6-ui-features/WorldMap/MapLocation.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 
 type MapLocationProps = {

--- a/src/6-ui-features/WorldMap/index.tsx
+++ b/src/6-ui-features/WorldMap/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import { useDispatch, useSelector as useReduxSelector } from 'react-redux';
 import { useSelector } from '4-react-ecsal';

--- a/src/6-ui-features/WorldMap/useDataLayerRenderer.ts
+++ b/src/6-ui-features/WorldMap/useDataLayerRenderer.ts
@@ -1,11 +1,11 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, RefObject } from 'react';
 import { DataLayer } from '1-game-code/World';
 import { Color } from './Color';
 import PixelMap from './PixelMap';
 
 /** Renders a DataLayer onto a canvas via PixelMap and ImageBitmap */
 export function useDataLayerRenderer(
-  canvasRef: React.RefObject<HTMLCanvasElement>,
+  canvasRef: RefObject<HTMLCanvasElement>,
   colorFunc: (num: number) => Color,
   dataLayer?: DataLayer,
 

--- a/src/7-app/SceneRouter.tsx
+++ b/src/7-app/SceneRouter.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import { useSelector } from 'react-redux';
 

--- a/src/7-app/tests/buyItems.integration.test.tsx
+++ b/src/7-app/tests/buyItems.integration.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen, waitFor, waitForElementToBeRemoved } from '8-helpers/test-utils';
 import userEvent from '@testing-library/user-event';
 import App from '../../App';

--- a/src/8-helpers/test-utils.tsx
+++ b/src/8-helpers/test-utils.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
+import { FunctionComponent, ReactNode } from 'react';
 import { render as rtlRender, RenderResult } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore, ConfigureStoreOptions } from '@reduxjs/toolkit';
 import rootReducer from '7-app/rootReducer';
 
 type WrapperProps = {
-  children?: React.ReactNode;
+  children?: ReactNode;
 };
 
 function render(
@@ -18,7 +18,7 @@ function render(
   return rtlRender(component, { wrapper: Wrapper, ...renderOptions });
 }
 
-function createRenderer<ComponentProps>(Component: React.FunctionComponent<ComponentProps>) {
+function createRenderer<ComponentProps>(Component: FunctionComponent<ComponentProps>) {
   return (
     props: ComponentProps,
     { reducer = rootReducer, ...configureStoreOptions }: Partial<ConfigureStoreOptions> = {},

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { store } from './7-app/store';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { GameManager } from '0-engine/GameManager';
 import { Provider as EcsalProvider } from '4-react-ecsal';
 import { TestProvider } from '6-ui-features/TestContext';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { StrictMode } from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
 import { Provider } from 'react-redux';
@@ -9,11 +9,11 @@ const render = async () => {
   const App = (await import('./App')).default;
 
   ReactDOM.render(
-    <React.StrictMode>
+    <StrictMode>
       <Provider store={store}>
         <App />
       </Provider>
-    </React.StrictMode>,
+    </StrictMode>,
     document.getElementById('root'),
   );
 };


### PR DESCRIPTION
- As of React 17, we no longer need to import react to use JSX, if
  we're using the new JSX transform, which CRA 4.0 uses by default.
- Disabled related eslint rules

Fixes: nmkataoka/adv-life#358

## Checklist

- [x] PR is of reasonable size
