### PR TITLE
Standardize Entity type, use Map in component managers

### DIFF
--- a/src/0-engine/ECS/Entity.ts
+++ b/src/0-engine/ECS/Entity.ts
@@ -1,0 +1,1 @@
+export type Entity = number;

--- a/src/0-engine/ECS/view/View.ts
+++ b/src/0-engine/ECS/view/View.ts
@@ -94,7 +94,7 @@ function FindEntitiesWithComponents(cMgrs: ComponentManager<any>[], without: num
       }
 
       if (hasAllComponents) {
-        viewEntities.push(parseInt(e, 10));
+        viewEntities.push(e);
       }
     }
   }

--- a/src/0-engine/index.ts
+++ b/src/0-engine/index.ts
@@ -6,3 +6,4 @@ export { NComponent } from './ECS/NComponent';
 export type { NComponentConstructor } from './ECS/NComponent';
 export type { Thunk } from './ECS/Thunk';
 export { View } from './ECS/view/View';
+export type { Entity } from './ECS/Entity';

--- a/src/1-game-code/Agent/AgentSys.ts
+++ b/src/1-game-code/Agent/AgentSys.ts
@@ -34,8 +34,8 @@ const agentUpdateSlice = createEventSlice(DefaultEvent.Update, {
     },
     payload: { dt },
   }) => {
-    const promises = agentMgr.entries().map(async ([entityString, agentCmpt]) => {
-      const self = parseInt(entityString, 10);
+    const promises = agentMgr.entries().map(async ([e, agentCmpt]) => {
+      const self = e;
       let { baction } = agentCmpt;
 
       // Get new action if necessary
@@ -113,11 +113,9 @@ function attackRandomEnemy(
 }
 
 function getEnemies(factionMgr: ComponentManager<FactionCmpt>, isEnemy: boolean): number[] {
-  const enemies = Object.entries(factionMgr.getAsArray()).filter(
-    ([, factionCmpt]) => factionCmpt.isEnemy !== isEnemy,
-  );
+  const enemies = factionMgr.entries().filter(([, factionCmpt]) => factionCmpt.isEnemy !== isEnemy);
 
-  return enemies.map(([entityStr]) => parseInt(entityStr, 10));
+  return enemies.map(([e]) => e);
 }
 
 export default [agentStartSlice.eventListener, agentUpdateSlice.eventListener];

--- a/src/1-game-code/Agent/ProcRuleData/fireball.ts
+++ b/src/1-game-code/Agent/ProcRuleData/fireball.ts
@@ -104,7 +104,7 @@ function getTargetsInAoeRadius(
   // Get enemies in combat order
   const enemies = factionMgr.entries().filter((faction) => faction[1].isEnemy);
   const enemyPositions: EntityCombatPos[] = enemies.map((e) => {
-    const entityHandle = parseInt(e[0], 10);
+    const entityHandle = e[0];
     const combatPos = combatPositionMgr.getMut(entityHandle);
     return { entityHandle, combatPos };
   });

--- a/src/1-game-code/Combat/AttackSys.ts
+++ b/src/1-game-code/Combat/AttackSys.ts
@@ -1,10 +1,10 @@
-import { createEventSliceWithView, DefaultEvent } from '0-engine';
+import { createEventSliceWithView, DefaultEvent, Entity } from '0-engine';
 import { HealthCmpt } from '../ncomponents/HealthCmpt';
 
 const checkForDeathsSlice = createEventSliceWithView(DefaultEvent.Update, {
   readCmpts: [HealthCmpt],
 })<undefined>(function checkForDeaths({ eMgr, view }) {
-  view.forEach((e: number | string, { readCmpts: [healthCmpt] }) => {
+  view.forEach((e: Entity, { readCmpts: [healthCmpt] }) => {
     if (healthCmpt.health <= 0) {
       eMgr.queueEntityDestruction(e);
     }

--- a/src/3-frontend-api/inventory/getInventory.ts
+++ b/src/3-frontend-api/inventory/getInventory.ts
@@ -1,11 +1,9 @@
-import { EntityManager } from '0-engine';
+import { Entity, EntityManager } from '0-engine';
 import { InventoryCmpt } from '1-game-code/Inventory';
 import { Selector } from '4-react-ecsal';
 import { defaultInventorySlotInfo, InventoryInfo } from './InventoryInfo';
 
-export const getInventory = (e: number | string): Selector<InventoryInfo> => (
-  eMgr: EntityManager,
-) => {
+export const getInventory = (e: Entity): Selector<InventoryInfo> => (eMgr: EntityManager) => {
   const { gold = 0, inventorySlots = [] } = eMgr.tryGetCmpt(InventoryCmpt, e) ?? {};
   return {
     gold,

--- a/src/6-ui-features/CharacterInfo/CharacterEquipment.tsx
+++ b/src/6-ui-features/CharacterInfo/CharacterEquipment.tsx
@@ -1,10 +1,10 @@
 import styled from '@emotion/styled';
 import { useSelector } from '4-react-ecsal';
-import { EntityManager } from '0-engine';
+import { Entity, EntityManager } from '0-engine';
 import { InventoryCmpt } from '1-game-code/ncomponents';
 import { getPlayerId } from '3-frontend-api';
 
-const selectPlayerGold = (player: number | string) => (eMgr: EntityManager) => {
+const selectPlayerGold = (player: Entity) => (eMgr: EntityManager) => {
   const { gold } = eMgr.getCmpt(InventoryCmpt, player);
   return gold;
 };


### PR DESCRIPTION
- Changed component managers to use Map, which is better than JS Object
  for what we're trying to do here
- Created an Entity type which is just a number for clarity

Fixes: nmkataoka/adv-life#380

Also fixes nmkataoka/adv-life#381

## Checklist

- [x] PR is of reasonable size
