### PR TITLE
Track component versions in engine

### DIFF
--- a/src/0-engine/ECS/component-manager/ComponentManager.test.ts
+++ b/src/0-engine/ECS/component-manager/ComponentManager.test.ts
@@ -1,4 +1,4 @@
-import { ComponentManager } from './ComponentManager';
+import { componentHasntChanged, ComponentManager } from './ComponentManager';
 import { NComponent } from '../NComponent';
 
 class TestCmpt extends NComponent {
@@ -33,5 +33,24 @@ describe('component manager', () => {
       const cmpt = cMgr.getMut(i);
       expect(cmpt?.health).toBe(i * 10);
     }
+  });
+
+  it('when component is accessed via immutable ref, mutation tracking detects no change', () => {
+    const cMgr = new ComponentManager<TestCmpt>(TestCmpt);
+
+    cMgr.add(0, new TestCmpt());
+    const ref1 = cMgr.getWithVersion(0);
+    const ref2 = cMgr.getWithVersion(0);
+    expect(componentHasntChanged(ref1, ref2)).toBe(true);
+  });
+
+  it('when component is mutated, mutation tracking detects a change', () => {
+    const cMgr = new ComponentManager<TestCmpt>(TestCmpt);
+    cMgr.add(0, new TestCmpt());
+    const ref1 = cMgr.getWithVersion(0);
+    const cmpt = cMgr.getMut(0);
+    cmpt.health -= 1;
+    const ref2 = cMgr.getWithVersion(0);
+    expect(componentHasntChanged(ref1, ref2)).toBe(false);
   });
 });

--- a/src/0-engine/index.ts
+++ b/src/0-engine/index.ts
@@ -2,6 +2,7 @@ export { DefaultEvent, NameCmpt } from './ECS/built-in-components';
 export { EventCallbackError } from './ECS/event-system';
 export { copyEventSlice, createEventSlice, createEventSliceWithView } from './ECS/event-system';
 export { GetComponent, GetComponentManager, EntityManager } from './ECS/EntityManager';
+export { componentHasntChanged } from './ECS/component-manager/ComponentManager';
 export { NComponent } from './ECS/NComponent';
 export type { NComponentConstructor } from './ECS/NComponent';
 export type { Thunk } from './ECS/Thunk';


### PR DESCRIPTION
We need to track component versions in order to detect state mutations
for the react-ecsal bindings.

Fixes: nmkataoka/adv-life#382

## Checklist

- [x] PR is of reasonable size
