### PR TITLE
Make sure selectors return new references

### DIFF
--- a/src/3-frontend-api/combat/index.ts
+++ b/src/3-frontend-api/combat/index.ts
@@ -10,7 +10,8 @@ const getUnitCombatPos = (unitId: Entity): ComponentNode<CombatPositionCmpt> =>
 export const getUnitPosition = selectorNodeFamily({
   get: (unitId: Entity) => ({ get }) => {
     const [combatPos] = get(getUnitCombatPos(unitId));
-    return combatPos?.pos;
+    if (!combatPos) return undefined;
+    return { ...combatPos.pos };
   },
   computeKey: (unitId: Entity) => `${unitId}`,
 });

--- a/src/3-frontend-api/combatLog/index.ts
+++ b/src/3-frontend-api/combatLog/index.ts
@@ -3,6 +3,6 @@ import { selectorNode } from '4-react-ecsal';
 
 export const getCombatLog = selectorNode({
   get: () => {
-    return combatLog;
+    return [...combatLog];
   },
 });

--- a/src/3-frontend-api/worldMap/getTerrainInfo.ts
+++ b/src/3-frontend-api/worldMap/getTerrainInfo.ts
@@ -7,6 +7,6 @@ export const getElevationMetadata = selectorNode({
     const [worldMapCmpt] = get(getWorldMap);
     if (!worldMapCmpt) return undefined;
     const result = worldMapCmpt.data.metadata[WorldMap.Layer.Elevation];
-    return result;
+    return result ? { ...result } : undefined;
   },
 });


### PR DESCRIPTION
Selectors must return new references if the object has mutated. Since
the underlying engine can mutate objects without assigning them new
references, selectors need to make sure arrays/objects are shallow
copied (possibly deep copied if we need to change references of
properties).

Fixes: nmkataoka/adv-life#417

## Checklist

- [x] PR is of reasonable size
