### PR TITLE
Randomize rain layer

### DIFF
--- a/src/1-game-code/Town/RouteCmpt.ts
+++ b/src/1-game-code/Town/RouteCmpt.ts
@@ -1,0 +1,23 @@
+import { Entity, NComponent } from '0-engine';
+
+/** Routes connect two towns */
+export class RouteCmpt extends NComponent {
+  townA: Entity = -1;
+
+  townB: Entity = -1;
+
+  paving: RoutePaving = RoutePaving.Untread;
+}
+
+enum RoutePaving {
+  Untread = 0,
+  Trail = 1,
+  Paved = 2,
+}
+
+export function createRouteCmpt(townA: Entity, townB: Entity): RouteCmpt {
+  const route = new RouteCmpt();
+  route.townA = townA;
+  route.townB = townB;
+  return route;
+}

--- a/src/1-game-code/World/DataLayer/DataLayer.ts
+++ b/src/1-game-code/World/DataLayer/DataLayer.ts
@@ -15,7 +15,7 @@ export class DataLayer {
     name: string,
     width: number,
     height: number,
-    metersPerCoord = 4092,
+    metersPerCoord = 4096,
     isCylindridal = true,
   ) {
     this.name = name;

--- a/src/1-game-code/World/Hydrology/RainSys.ts
+++ b/src/1-game-code/World/Hydrology/RainSys.ts
@@ -1,20 +1,22 @@
 import { createEventSlice } from '0-engine';
 import { RngCmpt } from '1-game-code/prng/RngCmpt';
 import { Vector2 } from '8-helpers/math';
+import { DataLayer } from '../DataLayer/DataLayer';
 import { WorldMap } from '../WorldMap';
 import { WorldMapCmpt } from '../WorldMapCmpt';
 import { createDrop, descend, Drop } from './Drop';
-import { createConstantRainLayer } from './rainLayer';
+import { createConstantRainLayer, createRandomRainLayer } from './rainLayer';
 
 const startHydrologySlice = createEventSlice('startHydrology', {
   writeCmpts: [WorldMapCmpt],
-})<{ size: { x: number; y: number } }>(
+})<{ mode?: 'constant' | 'random' | 'real'; size: { x: number; y: number } }>(
   ({
     componentManagers: {
       writeCMgrs: [worldMapMgr],
     },
     payload: {
       size: { x, y },
+      mode = 'random',
     },
   }) => {
     const worldMapCmpt = worldMapMgr.getUniqueMut();
@@ -24,7 +26,16 @@ const startHydrologySlice = createEventSlice('startHydrology', {
     if (worldMapCmpt.data.dataLayers[WorldMap.Layer.Rain]) {
       throw new Error('Tried to create a hydrology layer when it already exists');
     }
-    worldMapCmpt.data.dataLayers[WorldMap.Layer.Rain] = createConstantRainLayer(x, y);
+
+    let rainLayer: DataLayer;
+    if (mode === 'constant') {
+      rainLayer = createConstantRainLayer(x, y);
+    } else if (mode === 'random') {
+      rainLayer = createRandomRainLayer(x, y);
+    } else {
+      throw new Error('Not implemented');
+    }
+    worldMapCmpt.data.dataLayers[WorldMap.Layer.Rain] = rainLayer;
   },
 );
 

--- a/src/1-game-code/World/Hydrology/rainLayer.ts
+++ b/src/1-game-code/World/Hydrology/rainLayer.ts
@@ -1,8 +1,23 @@
+import SimplexNoise from '10-simplex-noise';
 import { DataLayer } from '../DataLayer/DataLayer';
 import { WorldMap } from '../WorldMap';
 
 export function createConstantRainLayer(width: number, height: number): DataLayer {
   const rainLayer = new DataLayer(WorldMap.Layer.Rain, width, height);
   rainLayer.setAll(1);
+  return rainLayer;
+}
+
+export function createRandomRainLayer(width: number, height: number): DataLayer {
+  const rainLayer = new DataLayer(WorldMap.Layer.Rain, width, height);
+  const n = new SimplexNoise('test', {
+    frequency: 0.001,
+    octaves: 8,
+  });
+  for (let y = 0; y < height; ++y) {
+    for (let x = 0; x < width; ++x) {
+      rainLayer.set(x, y, n.noise2D(x, y));
+    }
+  }
   return rainLayer;
 }

--- a/src/1-game-code/World/Towns/townLayer.ts
+++ b/src/1-game-code/World/Towns/townLayer.ts
@@ -1,0 +1,48 @@
+import { Entity } from '0-engine';
+import { WorldMap } from '1-game-code/World/WorldMap';
+/**
+ * Since town data is much sparser than the world map grid resolution (4 km x 4 km),
+ * the townLayer uses a lower resolution DataLayer.
+ */
+export class SparseDataLayer<T> {
+  data: T[];
+
+  /** Height of grid in tiles, NOT in distance units. */
+  height: number;
+
+  /** Width of grid in tile, NOT in distance units. */
+  width: number;
+
+  name: string;
+
+  metersPerCoord: number;
+
+  isCylindrical = true;
+
+  constructor(
+    name: string,
+    width: number,
+    height: number,
+    initialize: () => T,
+    metersPerCoord = 65536,
+  ) {
+    this.name = name;
+    this.height = height;
+    this.width = width;
+    this.metersPerCoord = metersPerCoord;
+    this.data = [];
+
+    for (let i = 0; i < this.height * this.width; ++i) {
+      this.data.push(initialize());
+    }
+  }
+}
+
+export const createTownLayer = (width: number, height: number): SparseDataLayer<Entity> => {
+  const sparseWidth = Math.floor(width / 16);
+  const sparseHeight = Math.floor(height / 16);
+  if (sparseWidth !== width / 16 || sparseHeight !== height / 16) {
+    throw new Error('Map height and width must be divisible by 16!');
+  }
+  return new SparseDataLayer(WorldMap.Layer.Town, width / 16, height / 16, () => -1);
+};

--- a/src/1-game-code/World/WorldMap.ts
+++ b/src/1-game-code/World/WorldMap.ts
@@ -7,6 +7,7 @@ export class WorldMap {
     Elevation: 'elevation',
     Hilliness: 'hilliness',
     Rain: 'rain',
+    Town: 'town',
   } as const;
 
   dataLayers: { [key: string]: DataLayer } = {};

--- a/src/6-ui-features/WorldGenScene/Sidebar/createWorld.ts
+++ b/src/6-ui-features/WorldGenScene/Sidebar/createWorld.ts
@@ -16,7 +16,7 @@ export const createWorld = (seed: string, settings: typeof WorldGenModules): Thu
   await dispatch(createWorldMap(terrainGenParams));
 
   const { width, height } = terrainGenParams;
-  await dispatch(startHydrology({ size: { x: width, y: height } }));
+  await dispatch(startHydrology({ mode: 'random', size: { x: width, y: height } }));
 };
 
 /** Parses the UI settings data format into the payload expected by the backend */

--- a/src/6-ui-features/WorldGenScene/constants/terrainGenControls.ts
+++ b/src/6-ui-features/WorldGenScene/constants/terrainGenControls.ts
@@ -9,7 +9,7 @@ export const terrainGenControls: TabContentProps['content'] = [
       {
         name: 'Width (tiles)',
         key: 'width',
-        description: 'Map width in tiles. 1 tile = 4092 m.',
+        description: 'Map width in tiles. 1 tile = 4096 m.',
         value: 800,
         min: 100,
         max: 1600,
@@ -18,7 +18,7 @@ export const terrainGenControls: TabContentProps['content'] = [
       {
         name: 'Height (tiles)',
         key: 'height',
-        description: 'Map height in tiles. 1 tile = 4092 m.',
+        description: 'Map height in tiles. 1 tile = 4096 m.',
         value: 400,
         min: 50,
         max: 800,


### PR DESCRIPTION
- Added option to use noise to randomize rain layer
- There is a bit of work on Town/Route generation from an issue I
  started on briefly
- Fixed metersPerCoord from 4092 -> 4096 (supposed to be power of 2)

Fixes: nmkataoka/adv-life#440

## Checklist

- [x] PR is of reasonable size
