### PR TITLE
Display rain layer during world gen

### DIFF
--- a/src/1-game-code/World/DataLayer/DataLayer.ts
+++ b/src/1-game-code/World/DataLayer/DataLayer.ts
@@ -1,3 +1,5 @@
+import { WorldMapLayer } from './WorldMapLayers';
+
 export class DataLayer {
   data: Float32Array;
 
@@ -5,14 +7,14 @@ export class DataLayer {
 
   width: number;
 
-  name: string;
+  name: WorldMapLayer;
 
   metersPerCoord: number;
 
   isCylindrical: boolean;
 
   constructor(
-    name: string,
+    name: WorldMapLayer,
     width: number,
     height: number,
     metersPerCoord = 4096,
@@ -33,7 +35,7 @@ export class DataLayer {
    * This is not a deep copy -- assumes the source data will no longer be referenced.
    */
   public static constructFrom(data: Partial<DataLayer> = {}): DataLayer {
-    const { name = 'Unknown', width = 0, height = 0, metersPerCoord, isCylindrical } = data;
+    const { name = 'temp', width = 0, height = 0, metersPerCoord, isCylindrical } = data;
     const newDataLayer = new DataLayer(name, width, height, metersPerCoord, isCylindrical);
     if (data.data) {
       newDataLayer.data = data.data;

--- a/src/1-game-code/World/DataLayer/WorldMapLayers.ts
+++ b/src/1-game-code/World/DataLayer/WorldMapLayers.ts
@@ -1,0 +1,2 @@
+export const WorldMapLayers = ['elevation', 'hilliness', 'rain', 'temp'] as const;
+export type WorldMapLayer = typeof WorldMapLayers[number];

--- a/src/1-game-code/World/Hydrology/RainSys.ts
+++ b/src/1-game-code/World/Hydrology/RainSys.ts
@@ -2,7 +2,6 @@ import { createEventSlice } from '0-engine';
 import { RngCmpt } from '1-game-code/prng/RngCmpt';
 import { Vector2 } from '8-helpers/math';
 import { DataLayer } from '../DataLayer/DataLayer';
-import { WorldMap } from '../WorldMap';
 import { WorldMapCmpt } from '../WorldMapCmpt';
 import { createDrop, descend, Drop } from './Drop';
 import { createConstantRainLayer, createRandomRainLayer } from './rainLayer';
@@ -23,7 +22,7 @@ const startHydrologySlice = createEventSlice('startHydrology', {
     if (!worldMapCmpt) {
       throw new Error('Need a world map to create hydrology layer.');
     }
-    if (worldMapCmpt.data.dataLayers[WorldMap.Layer.Rain]) {
+    if (worldMapCmpt.data.dataLayers.rain) {
       throw new Error('Tried to create a hydrology layer when it already exists');
     }
 
@@ -35,7 +34,7 @@ const startHydrologySlice = createEventSlice('startHydrology', {
     } else {
       throw new Error('Not implemented');
     }
-    worldMapCmpt.data.dataLayers[WorldMap.Layer.Rain] = rainLayer;
+    worldMapCmpt.data.dataLayers.rain = rainLayer;
   },
 );
 
@@ -59,10 +58,11 @@ const rainSlice = createEventSlice('rain', {
     if (!worldMapCmpt) throw new Error("Tried to rain but world map doesn't exist yet.");
 
     // Future work, we could link in a true rain map/water cycle here
-    // const rainLayer = worldMapCmpt.data.dataLayers[WorldMap.Layer.Rain];
+    // const rainLayer = worldMapCmpt.data.dataLayers.rain;
 
     // Randomly "rain" a droplet of water on the map
-    const elevLayer = worldMapCmpt.data.dataLayers[WorldMap.Layer.Elevation];
+    const elevLayer = worldMapCmpt.data.dataLayers.elevation;
+    if (!elevLayer) throw new Error('Missing elevation layer.');
     const { height, width } = elevLayer;
     const rngCmpt = rngMgr.getUniqueMut();
     const rng = rngCmpt.getRng('WorldGen');

--- a/src/1-game-code/World/Hydrology/rainLayer.ts
+++ b/src/1-game-code/World/Hydrology/rainLayer.ts
@@ -1,15 +1,14 @@
 import SimplexNoise from '10-simplex-noise';
 import { DataLayer } from '../DataLayer/DataLayer';
-import { WorldMap } from '../WorldMap';
 
 export function createConstantRainLayer(width: number, height: number): DataLayer {
-  const rainLayer = new DataLayer(WorldMap.Layer.Rain, width, height);
+  const rainLayer = new DataLayer('rain', width, height);
   rainLayer.setAll(1);
   return rainLayer;
 }
 
 export function createRandomRainLayer(width: number, height: number): DataLayer {
-  const rainLayer = new DataLayer(WorldMap.Layer.Rain, width, height);
+  const rainLayer = new DataLayer('rain', width, height);
   const n = new SimplexNoise('test', {
     frequency: 0.001,
     octaves: 8,

--- a/src/1-game-code/World/Hydrology/surfaceNormal.test.ts
+++ b/src/1-game-code/World/Hydrology/surfaceNormal.test.ts
@@ -1,11 +1,10 @@
 import { Vector2 } from '8-helpers/math';
 import { DataLayer } from '../DataLayer/DataLayer';
-import { WorldMap } from '../WorldMap';
 import { surfaceNormal } from './surfaceNormal';
 
 describe('surfaceNormal', () => {
   it('returns correct norm for flat ground', () => {
-    const elevs = new DataLayer(WorldMap.Layer.Elevation, 3, 3, 1, false);
+    const elevs = new DataLayer('elevation', 3, 3, 1, false);
     elevs.setAll(0);
     const norm = surfaceNormal(elevs, new Vector2(1, 1), 1);
     const { x, y, z } = norm;

--- a/src/1-game-code/World/Hydrology/surfaceNormal.ts
+++ b/src/1-game-code/World/Hydrology/surfaceNormal.ts
@@ -1,10 +1,9 @@
 import { Vector2, Vector3 } from '8-helpers/math';
 import { DataLayer } from '../DataLayer/DataLayer';
-import { WorldMap } from '../WorldMap';
 
 /** Approximates the surface normal at a grid point by averaging 4 cross products. */
 export function surfaceNormal(e: DataLayer, coord: Vector2, scale: number): Vector3 {
-  if (e.name !== WorldMap.Layer.Elevation) {
+  if (e.name !== 'elevation') {
     throw new Error(`Wrong layer ${e.name} passed to surface normal function.`);
   }
   const { x, y } = coord;

--- a/src/1-game-code/World/TerrainGen/TerrainGenSys.ts
+++ b/src/1-game-code/World/TerrainGen/TerrainGenSys.ts
@@ -2,7 +2,6 @@ import { createEventSlice } from '0-engine';
 import { NoiseParams } from '1-game-code/Noise';
 import { RngCmpt } from '1-game-code/prng/RngCmpt';
 import { WorldMapCmpt } from '../WorldMapCmpt';
-import { WorldMap } from '../WorldMap';
 import { createRandomTerrain } from './elevationNoise/createRandomTerrain';
 import { generateTectonics } from './tectonicGeneration';
 import { rasterizeTectonics } from './tectonicRasterization';
@@ -26,7 +25,7 @@ const createNoisedWorldMapSlice = createEventSlice('createNoisedWorldMap', {
     }
     const worldMapEntity = eMgr.createEntity('worldMap');
     const worldMapCmpt = new WorldMapCmpt();
-    worldMapCmpt.data.dataLayers[WorldMap.Layer.Elevation] = createRandomTerrain();
+    worldMapCmpt.data.dataLayers.elevation = createRandomTerrain();
 
     worldMapMgr.add(worldMapEntity, worldMapCmpt);
   },
@@ -97,8 +96,8 @@ const createWorldMapSlice = createEventSlice('createWorldMap', {
       ridgeNoiseParams.scale,
       worldRng,
     );
-    worldMap.dataLayers[WorldMap.Layer.Elevation] = elevLayer;
-    worldMap.dataLayers[WorldMap.Layer.Hilliness] = hillinessLayer;
+    worldMap.dataLayers.elevation = elevLayer;
+    worldMap.dataLayers.hilliness = hillinessLayer;
     boxBlur(elevLayer, 2);
     lowFreqNoise(elevLayer, lowFreqNoiseParams);
     for (let i = 0; i < 10; ++i) {
@@ -106,7 +105,7 @@ const createWorldMapSlice = createEventSlice('createWorldMap', {
     }
     ridgeNoise(elevLayer, hillinessLayer, ridgeNoiseParams);
 
-    worldMap.metadata[WorldMap.Layer.Elevation] = calculateElevationMetadata(elevLayer);
+    worldMap.metadata.elevation = calculateElevationMetadata(elevLayer);
 
     worldMapMgr.add(worldMapEntity, worldMapCmpt);
   },

--- a/src/1-game-code/World/TerrainGen/elevationNoise/createRandomTerrain.ts
+++ b/src/1-game-code/World/TerrainGen/elevationNoise/createRandomTerrain.ts
@@ -1,4 +1,3 @@
-import { WorldMap } from '1-game-code/World/WorldMap';
 import SimplexNoise from '10-simplex-noise';
 import { DataLayer } from '../../DataLayer/DataLayer';
 
@@ -6,7 +5,7 @@ import { DataLayer } from '../../DataLayer/DataLayer';
  * mostly for debugging.
  */
 export function createRandomTerrain(): DataLayer {
-  const elevations = new DataLayer(WorldMap.Layer.Elevation, 400, 300);
+  const elevations = new DataLayer('elevation', 400, 300);
   const simplex = new SimplexNoise('seed', { frequency: 0.005, octaves: 8 });
   for (let y = 0; y < elevations.height; ++y) {
     for (let x = 0; x < elevations.width; ++x) {

--- a/src/1-game-code/World/TerrainGen/tectonicRasterization/fillInHoles.test.ts
+++ b/src/1-game-code/World/TerrainGen/tectonicRasterization/fillInHoles.test.ts
@@ -6,7 +6,7 @@ describe('fillInHoles', () => {
   const empty = -11000000;
   describe('findMostCommonElevationOnHoleBorder', () => {
     it('finds correct elevation in simple case', () => {
-      const map = new DataLayer(WorldMap.Layer.Elevation, 3, 3);
+      const map = new DataLayer('elevation', 3, 3);
       const data = [
         [1, 1, 1],
         [2, empty, 2],
@@ -24,7 +24,7 @@ describe('fillInHoles', () => {
         [0, empty, empty, 0],
         [3, 1, empty, 3],
       ];
-      const map = new DataLayer(WorldMap.Layer.Elevation, 4, 4);
+      const map = new DataLayer('elevation', 4, 4);
       data.forEach((row, rowIdx) => row.forEach((el, colIdx) => map.set(rowIdx, colIdx, el)));
       const mostCommonElev = findMostCommonElevationOnHoleBorder(map, { x: 1, y: 2 }, 2);
       expect(mostCommonElev).toEqual(3);

--- a/src/1-game-code/World/TerrainGen/tectonicRasterization/propagateElevationsFromFaults.ts
+++ b/src/1-game-code/World/TerrainGen/tectonicRasterization/propagateElevationsFromFaults.ts
@@ -1,6 +1,5 @@
 import { DataLayer } from '1-game-code/World/DataLayer/DataLayer';
 import { Vector2 } from '8-helpers/math';
-import { WorldMap } from '1-game-code/World/WorldMap';
 import SimplexNoise from '10-simplex-noise';
 import { Random } from '1-game-code/prng';
 import { convergence, Fault, hasSamePlateTypes, MAX_CONVERGENCE } from '../Fault';
@@ -59,7 +58,9 @@ export function propagateElevationsFromFaults(
   rng: Random,
 ): void {
   const { width, height, metersPerCoord } = elevLayer;
-  const elevChanges = new DataLayer('elevChanges', width, height, metersPerCoord);
+
+  // Temporary elevation layer to hold changes in elevation
+  const elevChanges = new DataLayer('temp', width, height, metersPerCoord);
   elevChanges.setAll(0);
   faults.forEach((fault) => {
     const { vertices } = fault;
@@ -303,7 +304,7 @@ function applyFaultFeature(
   if (feature.elevProfile.length < 2) {
     throw new Error('Fault feature elev profile is missing entries.');
   }
-  if (hillinessLayer.name !== WorldMap.Layer.Hilliness) {
+  if (hillinessLayer.name !== 'hilliness') {
     throw new Error(`Wrong data layer ${hillinessLayer.name} passed instead of hilliness layer`);
   }
 

--- a/src/1-game-code/World/TerrainGen/tectonicRasterization/rasterizeTecPlates.ts
+++ b/src/1-game-code/World/TerrainGen/tectonicRasterization/rasterizeTecPlates.ts
@@ -1,4 +1,3 @@
-import { WorldMap } from '1-game-code/World/WorldMap';
 import { Random } from '1-game-code/prng';
 import { fillInHoles } from './fillInHoles';
 import { DataLayer } from '../../DataLayer/DataLayer';
@@ -22,14 +21,14 @@ export function rasterizeTectonics(
   rng: Random,
   debug = false,
 ): { elevLayer: DataLayer; hillinessLayer: DataLayer } {
-  const elevLayer = new DataLayer(WorldMap.Layer.Elevation, width, height);
+  const elevLayer = new DataLayer('elevation', width, height);
   // Note that default uninitialized value is 11 million
   elevLayer.setAll(-11000000);
   rasterizeFaults(elevLayer, faults);
   fillInHoles(elevLayer, numPlates);
   shapeCoasts(elevLayer, faults, tecPlates, coastSlope, rng);
 
-  const hillinessLayer = new DataLayer(WorldMap.Layer.Hilliness, width, height);
+  const hillinessLayer = new DataLayer('hilliness', width, height);
   hillinessLayer.setAll(defaultHilliness);
   propagateElevationsFromFaults(
     elevLayer,

--- a/src/1-game-code/World/Towns/townLayer.ts
+++ b/src/1-game-code/World/Towns/townLayer.ts
@@ -1,5 +1,4 @@
 import { Entity } from '0-engine';
-import { WorldMap } from '1-game-code/World/WorldMap';
 /**
  * Since town data is much sparser than the world map grid resolution (4 km x 4 km),
  * the townLayer uses a lower resolution DataLayer.
@@ -44,5 +43,5 @@ export const createTownLayer = (width: number, height: number): SparseDataLayer<
   if (sparseWidth !== width / 16 || sparseHeight !== height / 16) {
     throw new Error('Map height and width must be divisible by 16!');
   }
-  return new SparseDataLayer(WorldMap.Layer.Town, width / 16, height / 16, () => -1);
+  return new SparseDataLayer('town', width / 16, height / 16, () => -1);
 };

--- a/src/1-game-code/World/WorldMap.ts
+++ b/src/1-game-code/World/WorldMap.ts
@@ -1,19 +1,13 @@
 import { DataLayer } from './DataLayer/DataLayer';
 import { defaultTectonics, Tectonics } from './TerrainGen/Tectonics';
 import { ElevationMetadata } from './TerrainGen/metadata';
+import { WorldMapLayer } from './DataLayer/WorldMapLayers';
 
 export class WorldMap {
-  static Layer = {
-    Elevation: 'elevation',
-    Hilliness: 'hilliness',
-    Rain: 'rain',
-    Town: 'town',
-  } as const;
-
-  dataLayers: { [key: string]: DataLayer } = {};
+  dataLayers: Partial<Record<WorldMapLayer, DataLayer>> = {};
 
   metadata: {
-    [WorldMap.Layer.Elevation]?: ElevationMetadata;
+    elevation?: ElevationMetadata;
   } = {};
 
   tectonics: Tectonics = { ...defaultTectonics };

--- a/src/3-frontend-api/worldMap/getTerrainInfo.ts
+++ b/src/3-frontend-api/worldMap/getTerrainInfo.ts
@@ -1,4 +1,3 @@
-import { WorldMap } from '1-game-code/World/WorldMap';
 import { selectorNode } from '4-react-ecsal';
 import { getWorldMap } from './getWorldMap';
 
@@ -6,7 +5,7 @@ export const getElevationMetadata = selectorNode({
   get: ({ get }) => {
     const [worldMapCmpt] = get(getWorldMap);
     if (!worldMapCmpt) return undefined;
-    const result = worldMapCmpt.data.metadata[WorldMap.Layer.Elevation];
+    const result = worldMapCmpt.data.metadata.elevation;
     return result ? { ...result } : undefined;
   },
 });

--- a/src/3-frontend-api/worldMap/getWorldMap.ts
+++ b/src/3-frontend-api/worldMap/getWorldMap.ts
@@ -1,15 +1,16 @@
 import { DataLayer } from '1-game-code/World';
+import { WorldMapLayer } from '1-game-code/World/DataLayer/WorldMapLayers';
 import { WorldMapCmpt } from '1-game-code/World/WorldMapCmpt';
 import { selectorNodeFamily, uniqueComponentNode } from '4-react-ecsal';
 
 export const getWorldMap = uniqueComponentNode(WorldMapCmpt);
 
 export const getWorldMapLayer = selectorNodeFamily({
-  get: (layer: string) => ({ get }) => {
+  get: (layer: WorldMapLayer) => ({ get }) => {
     const [worldMapCmpt] = get(getWorldMap);
     if (!worldMapCmpt) return undefined;
     const dataLayer = DataLayer.constructFrom(worldMapCmpt.data.dataLayers[layer] as DataLayer);
     return dataLayer;
   },
-  computeKey: (layer: string) => layer,
+  computeKey: (layer: WorldMapLayer) => layer,
 });

--- a/src/6-ui-features/WorldGenScene/Map.tsx
+++ b/src/6-ui-features/WorldGenScene/Map.tsx
@@ -1,16 +1,17 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 import styled from '@emotion/styled';
 import { useDataLayerRenderer } from '6-ui-features/WorldMap/useDataLayerRenderer';
 import { colorElevation } from '6-ui-features/WorldMap/coloringFuncs';
-import { WorldMap } from '1-game-code/World/WorldMap';
 import { getWorldMapLayer } from '3-frontend-api/worldMap';
 import { useSelector2 } from '4-react-ecsal';
 import useZoomOnScroll from '5-react-components/useZoomOnScroll';
 import { useElementSize } from '5-react-components/useElementSize';
+import { WorldMapLayer } from '1-game-code/World/DataLayer/WorldMapLayers';
 import { MapOverlay } from './MapOverlay';
 
 export function Map(): JSX.Element {
-  const elevations = useSelector2(getWorldMapLayer(WorldMap.Layer.Elevation));
+  const [currentLayer, setCurrentLayer] = useState<WorldMapLayer>('elevation');
+  const elevations = useSelector2(getWorldMapLayer(currentLayer));
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const scale = useZoomOnScroll(canvasRef);
@@ -24,7 +25,7 @@ export function Map(): JSX.Element {
       {!elevations && 'No map generated yet.'}
       <FullDiv ref={containerRef}>
         <canvas style={{ position: 'absolute' }} ref={canvasRef} height={height} width={width} />
-        {elevations && <MapOverlay />}
+        {elevations && <MapOverlay currentLayer={currentLayer} onLayerChange={setCurrentLayer} />}
       </FullDiv>
     </Container>
   );

--- a/src/6-ui-features/WorldGenScene/MapOverlay/LayerButtons.tsx
+++ b/src/6-ui-features/WorldGenScene/MapOverlay/LayerButtons.tsx
@@ -1,0 +1,46 @@
+import { WorldMapLayer } from '1-game-code/World/DataLayer/WorldMapLayers';
+import styled from '@emotion/styled';
+
+const buttons: { text: string; value: WorldMapLayer }[] = [
+  { text: 'Elevation', value: 'elevation' },
+  { text: 'Rainfall', value: 'rain' },
+];
+
+type LayerButtonsProps = {
+  currentLayer: WorldMapLayer;
+  onLayerChange: (newLayer: WorldMapLayer) => void;
+};
+
+export function LayerButtons({ currentLayer, onLayerChange }: LayerButtonsProps): JSX.Element {
+  return (
+    <ColumnContainer>
+      {buttons.map(({ text, value }) => (
+        <LayerButton
+          key={value}
+          isselected={currentLayer === value}
+          onClick={() => onLayerChange(value)}
+        >
+          {text}
+        </LayerButton>
+      ))}
+    </ColumnContainer>
+  );
+}
+
+const ColumnContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+`;
+
+type LayerButtonProps = {
+  isselected?: boolean;
+};
+
+const LayerButton = styled.button<LayerButtonProps>`
+  ${(props) => props.isselected && `background-color: lightgray;`}
+  margin: 0.5em;
+  margin-bottom: 0;
+  padding: 0.5em 1em;
+  width: 8em;
+`;

--- a/src/6-ui-features/WorldGenScene/MapOverlay/index.tsx
+++ b/src/6-ui-features/WorldGenScene/MapOverlay/index.tsx
@@ -1,8 +1,15 @@
+import { WorldMapLayer } from '1-game-code/World/DataLayer/WorldMapLayers';
 import { getElevationMetadata } from '3-frontend-api/worldMap/getTerrainInfo';
 import { useSelector2 } from '4-react-ecsal';
 import styled from '@emotion/styled';
+import { LayerButtons } from './LayerButtons';
 
-export function MapOverlay(): JSX.Element {
+type MapOverlayProps = {
+  currentLayer: WorldMapLayer;
+  onLayerChange: (newLayer: WorldMapLayer) => void;
+};
+
+export function MapOverlay({ currentLayer, onLayerChange }: MapOverlayProps): JSX.Element {
   const elevMeta = useSelector2(getElevationMetadata);
 
   return (
@@ -24,6 +31,7 @@ export function MapOverlay(): JSX.Element {
           </>
         )}
       </OverallStatsContainer>
+      <LayerButtons currentLayer={currentLayer} onLayerChange={onLayerChange} />
     </OverlayContainer>
   );
 }
@@ -36,6 +44,8 @@ const OverlayContainer = styled.div`
   position: absolute;
   height: 100%;
   width: 100%;
+
+  display: flex;
 `;
 
 const OverallStatsContainer = styled.div`

--- a/src/6-ui-features/WorldMap/PixelMap.test.ts
+++ b/src/6-ui-features/WorldMap/PixelMap.test.ts
@@ -39,7 +39,7 @@ describe('PixelMap', () => {
     global.ImageData = originalImageData;
   });
   it('outputs correct colors for simple map', () => {
-    const elevs = new DataLayer(WorldMap.Layer.Elevation, 2, 2);
+    const elevs = new DataLayer('elevation', 2, 2);
     elevs.set(1, 0, 1);
     elevs.set(0, 1, 2);
     elevs.set(1, 1, 3);

--- a/src/6-ui-features/WorldMap/PixelMap.ts
+++ b/src/6-ui-features/WorldMap/PixelMap.ts
@@ -103,7 +103,8 @@ export default class PixelMap {
  * Uses interpolation, so there is loss of data at map edges.
  */
 function shearElevs(map: DataLayer, shearFrac = 0.004): DataLayer {
-  const output = new DataLayer('shearedElevations', map.width, map.height);
+  // Temporary data layer to hold sheared elevations
+  const output = new DataLayer('temp', map.width, map.height);
   output.setAll(-1000000);
   /**
    *

--- a/src/6-ui-features/WorldMap/WorldMapCanvas.tsx
+++ b/src/6-ui-features/WorldMap/WorldMapCanvas.tsx
@@ -1,4 +1,3 @@
-import { WorldMap } from '1-game-code/World/WorldMap';
 import { getWorldMapLayer } from '3-frontend-api/worldMap';
 import { useSelector2 } from '4-react-ecsal';
 import { useReduxSelector } from '11-redux-wrapper';
@@ -19,7 +18,7 @@ type WorldMapCanvasProps = {
 // There is significant code overlap with the Map component
 export default function WorldMapCanvas({ height, width }: WorldMapCanvasProps): JSX.Element {
   const useShearedElev = useReduxSelector((state: RootState) => state.worldMap.useShearedElev);
-  const elevations = useSelector2(getWorldMapLayer(WorldMap.Layer.Elevation));
+  const elevations = useSelector2(getWorldMapLayer('elevation'));
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const scale = useZoomOnScroll(canvasRef);
 


### PR DESCRIPTION
- Allow switching between data layers during world gen
- Render rain layer during world gen
- Convert WorldMap.Layer from enum to union

Fixes: nmkataoka/adv-life#444

## Checklist

- [x] PR is of reasonable size
