### PR TITLE
Fix a random test

### DIFF
--- a/src/1-game-code/Town/createTownName.test.ts
+++ b/src/1-game-code/Town/createTownName.test.ts
@@ -8,9 +8,17 @@ describe('createTownName', () => {
 
   it('generates different names on subsequent calls', () => {
     const name1 = createTownName(Math);
-    const name2 = createTownName(Math);
     expect(name1.length).toBeGreaterThan(0);
-    expect(name2.length).toBeGreaterThan(0);
+
+    // Since it's random, it's rarely possible for the same name to generate twice.
+    // Just in case, we'll give it a few tries.
+    let name2 = createTownName(Math);
+    let tries = 1;
+    while (name1 === name2 && tries < 10) {
+      name2 = createTownName(Math);
+      ++tries;
+    }
+
     expect(name1).not.toBe(name2);
   });
 });


### PR DESCRIPTION
- A test relying on a random number generator was testing for different
  values on subsequent calls. It's possible for the same value to
  occur twice in a row (and did occur) during tests. Fixed it to retry
  10 times. While it's still possible for valid code to generate the
  same value 10 times in a row, it seems pretty unlikely.
- No associated ticket

Fixes: nmkataoka/adv-life#

## Checklist

- [x] PR is of reasonable size
