### PR TITLE
Add town map icons

### DIFF
--- a/src/6-ui-features/DesignSystem/icons/index.ts
+++ b/src/6-ui-features/DesignSystem/icons/index.ts
@@ -1,1 +1,3 @@
 export { VillageIcon } from './VillageIcon';
+export { BaseIcon } from './BaseIcon';
+export type { BaseIconProps } from './BaseIcon';

--- a/src/6-ui-features/WorldMap/PoliticalOverlay/Town.tsx
+++ b/src/6-ui-features/WorldMap/PoliticalOverlay/Town.tsx
@@ -1,6 +1,6 @@
-import { VillageIcon } from '6-ui-features/DesignSystem/icons';
 import { getColor } from '6-ui-features/Theme';
 import styled from '@emotion/styled';
+import { VillageMapSymbolIcon } from '../icons';
 
 interface TownProps {
   name: string;
@@ -17,7 +17,7 @@ export function Town({ name, coords }: TownProps): JSX.Element {
   );
 }
 
-const Icon = styled(VillageIcon)`
+const Icon = styled(VillageMapSymbolIcon)`
   transform: translate(0, 65%);
 `;
 

--- a/src/6-ui-features/WorldMap/icons/CityMapSymbolIcon.tsx
+++ b/src/6-ui-features/WorldMap/icons/CityMapSymbolIcon.tsx
@@ -1,0 +1,18 @@
+import { BaseIcon, BaseIconProps } from '6-ui-features/DesignSystem/icons';
+
+interface CityMapSymbolIconProps extends BaseIconProps {
+  backgroundColor: string;
+}
+
+export function CityMapSymbolIcon({
+  backgroundColor,
+  ...props
+}: CityMapSymbolIconProps): JSX.Element {
+  return (
+    <BaseIcon {...props}>
+      <circle cx="8" cy="8" r="5" fill="currentColor" />
+      <circle cx="8" cy="8" r="4" fill={backgroundColor} />
+      <circle cx="8" cy="8" r="2" fill="currentColor" />
+    </BaseIcon>
+  );
+}

--- a/src/6-ui-features/WorldMap/icons/LICENSE.txt
+++ b/src/6-ui-features/WorldMap/icons/LICENSE.txt
@@ -1,0 +1,5 @@
+The following assets were made by Nolan Kataoka and are released under the same license as the adv-life source code.
+
+VillageMapSymbolIcon
+TownMapSymbolIcon
+CityMapSymbolIcon

--- a/src/6-ui-features/WorldMap/icons/TownMapSymbolIcon.tsx
+++ b/src/6-ui-features/WorldMap/icons/TownMapSymbolIcon.tsx
@@ -1,0 +1,17 @@
+import { BaseIcon, BaseIconProps } from '6-ui-features/DesignSystem/icons';
+
+interface TownMapSymbolIconProps extends BaseIconProps {
+  backgroundColor: string;
+}
+
+export function TownMapSymbolIcon({
+  backgroundColor,
+  ...props
+}: TownMapSymbolIconProps): JSX.Element {
+  return (
+    <BaseIcon {...props}>
+      <circle cx="8" cy="8" r="4" fill="currentColor" />
+      <circle cx="8" cy="8" r="3" fill={backgroundColor} />
+    </BaseIcon>
+  );
+}

--- a/src/6-ui-features/WorldMap/icons/VillageMapSymbolIcon.tsx
+++ b/src/6-ui-features/WorldMap/icons/VillageMapSymbolIcon.tsx
@@ -1,0 +1,9 @@
+import { BaseIcon, BaseIconProps } from '6-ui-features/DesignSystem/icons';
+
+export function VillageMapSymbolIcon(props: BaseIconProps): JSX.Element {
+  return (
+    <BaseIcon {...props}>
+      <circle cx="8" cy="8" r="3" fill="currentColor" />
+    </BaseIcon>
+  );
+}

--- a/src/6-ui-features/WorldMap/icons/index.ts
+++ b/src/6-ui-features/WorldMap/icons/index.ts
@@ -1,0 +1,3 @@
+export { CityMapSymbolIcon } from './CityMapSymbolIcon';
+export { TownMapSymbolIcon } from './TownMapSymbolIcon';
+export { VillageMapSymbolIcon } from './VillageMapSymbolIcon';


### PR DESCRIPTION
Created and added town map icons. Will keep the old VillageIcon around
since it'll probably be useful in other scenarios.

Fixes: nmkataoka/adv-life#419

## Checklist

- [x] PR is of reasonable size
